### PR TITLE
Disable simulator parallelization

### DIFF
--- a/Common/ThreadPool.h
+++ b/Common/ThreadPool.h
@@ -63,7 +63,7 @@ public:
 		++_priority;
 		lock.unlock();
 		
-	  size_t progress = end-start;
+		size_t progress = end-start;
 		
 		std::thread localThread(&ThreadPool::threadSpecificPriorityFunc, this, 0, thisPriority, &progress);
 		

--- a/DPPP/Simulator.cc
+++ b/DPPP/Simulator.cc
@@ -105,7 +105,13 @@ void Simulator::visit(const PointSource &component) {
   }
 
   // Compute visibilities.
-#pragma omp parallel for
+  // The following loop can be parallelized, but because there is already
+  // a parallelization over sources, this is not necessary.
+  // It used to be parallelized with a #pragma omp parallel for, but since
+  // the outer loop was also parallelized with omp, this had no effect
+  // (since omp by default doesn't parallelize nested loops). After the change
+  // to a ThreadPool, this would parallize each separate source, which started
+  // hundreds of threads on many-core machines.
   for(size_t bl = 0; bl < itsNBaseline; ++bl) {
     dcomplex* buffer=&itsBuffer(0,0,bl);
     const size_t p = itsBaselines[bl].first;

--- a/DPPP_DDECal/DDECal.cc
+++ b/DPPP_DDECal/DDECal.cc
@@ -611,22 +611,18 @@ namespace DP3 {
 
       itsTimerPredict.start();
 
-//      if(itsPredictSteps.size() < DP3OpenMP::maxThreads())
-//        DP3OpenMP::setNested(true);
       if (itsUseModelColumn) {
         itsInput->getModelData (itsBufs[itsStepInSolInt].getRowNrs(),
                                 itsModelData[itsStepInSolInt]);
         itsModelDataPtrs[itsStepInSolInt][0] = itsModelData[itsStepInSolInt].data();
       } else {
-//#pragma omp parallel for schedule(dynamic) if(itsPredictSteps.size()>1)
-//        for (size_t dir=0; dir<itsPredictSteps.size(); ++dir) {
         ThreadPool pool;
         for(DP3::DPPP::Predict& predict : itsPredictSteps)
           predict.setThreadPool(pool);
         pool.For(0, itsPredictSteps.size(), [&](size_t dir, size_t /*thread*/) {
           itsPredictSteps[dir].process(itsBufs[itsStepInSolInt]);
           itsModelDataPtrs[itsStepInSolInt][dir] =
-                   itsResultSteps[dir]->get()[itsStepInSolInt].getData().data();
+            itsResultSteps[dir]->get()[itsStepInSolInt].getData().data();
         });
       }
 


### PR DESCRIPTION
Fixes #11, which was related to #3 . This pool contains some left-over cleaning of OMP statements that caused slower performance, and implements a new ThreadPool. This ThreadPool has better performance and keeps all new loops running, causing it to occupy the full CPU as intended.