### PR TITLE
Bump minimum cmake requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.8)
+cmake_minimum_required(VERSION 3.0)
 
 project(DP3)
 


### PR DESCRIPTION
I ran into this error when using CMake 2.8.12.2.
```
CMake Error: Error in cmake code at
/home/dijkema/opt/DP3/src/CMake/FindPackageHandleStandardArgs.cmake:6:
Parse error.  Expected "(", got newline with text "
".
```

I guess that 3.0 should be recent enough: