### PR TITLE
Add old casacore include dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,9 @@ include_directories(${HDF5_INCLUDE_DIRS})
 
 find_package(Casacore COMPONENTS casa ms tables REQUIRED)
 include_directories(${CASACORE_INCLUDE_DIR})
+# Add old casacore include directory because LOFAR beam library did
+# not use the casacore/ prefix in the includes until 3.2 (Sep '18)
+include_directories(${CASACORE_INCLUDE_DIR}/casacore)
 
 #Prevent accidentally finding old BoostConfig.cmake file from casapy
 set(Boost_NO_BOOST_CMAKE ON)


### PR DESCRIPTION
This is to work around the fact that StationResponse.h until very recently used the old casacore include path (without the casacore prefix). The error thrown during build was:
```
In file included from /home/installdir/lofar/include/StationResponse/AntennaField.h:36:0,
                 from /home/installdir/lofar/include/StationResponse/Station.h:32,
                 from /home/installdir/DP3/DPPP/DPInput.h:36,
                 from /home/installdir/DP3/DPPP/MSReader.h:30,
                 from /home/installdir/DP3/DPPP/DPRun.h:31,
                 from /home/installdir/DP3/DPPP/DPRun.cc:24:
/home/installdir/lofar/include/StationResponse/ITRFDirection.h:32:41: fatal error: measures/Measures/MeasFrame.h: No such file or directory
compilation terminated.
```