### PR TITLE
Minimum cmake now 3.9 as required by FindHDF5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required(VERSION 3.0)
+# FindHDF5 uses NATIVE_COMMAND in separate_arguments, which requires
+# CMake 3.9.
+cmake_minimum_required(VERSION 3.9)
 
 project(DP3)
 


### PR DESCRIPTION
Turns out that the newer FindHDF5 uses an option called `NATIVE_COMMAND` inside `separate_arguments`, and this requires CMake >= 3.9.

The error given with lower cmake: (as reported by @shulevski )

> + cd /home/installdir/DP3/build
> + cmake ../
> -- The C compiler identification is GNU 5.4.0
> -- The CXX compiler identification is GNU 5.4.0
> -- Check for working C compiler: /usr/bin/cc
> -- Check for working C compiler: /usr/bin/cc -- works
> -- Detecting C compiler ABI info
> -- Detecting C compiler ABI info - done
> -- Detecting C compile features
> -- Detecting C compile features - done
> -- Check for working CXX compiler: /usr/bin/c++
> -- Check for working CXX compiler: /usr/bin/c++ -- works
> -- Detecting CXX compiler ABI info
> -- Detecting CXX compiler ABI info - done
> -- Detecting CXX compile features
> -- Detecting CXX compile features - done
> -- Try OpenMP C flag = [-fopenmp]
> -- Performing Test OpenMP_FLAG_DETECTED
> -- Performing Test OpenMP_FLAG_DETECTED - Success
> -- Try OpenMP CXX flag = [-fopenmp]
> -- Performing Test OpenMP_FLAG_DETECTED
> -- Performing Test OpenMP_FLAG_DETECTED - Success
> -- Found OpenMP: -fopenmp 
> -- HDF5: Using hdf5 compiler wrapper to determine C configuration
> CMake Error at CMake/FindHDF5.cmake:363 (separate_arguments):
>   separate_arguments given unknown argument NATIVE_COMMAND
> Call Stack (most recent call first):
>   CMake/FindHDF5.cmake:588 (_HDF5_parse_compile_line)
>   CMakeLists.txt:17 (find_package)
> 
> 
> -- HDF5: Using hdf5 compiler wrapper to determine CXX configuration
> CMake Error at CMake/FindHDF5.cmake:363 (separate_arguments):
>   separate_arguments given unknown argument NATIVE_COMMAND
> Call Stack (most recent call first):
>   CMake/FindHDF5.cmake:588 (_HDF5_parse_compile_line)
>   CMakeLists.txt:17 (find_package)
> 
> 
> CMake Error at CMake/FindPackageHandleStandardArgs.cmake:137 (message):
>   Could NOT find HDF5 (missing: HDF5_LIBRARIES) (found version "1.8.16")
> Call Stack (most recent call first):
>   CMake/FindPackageHandleStandardArgs.cmake:378 (_FPHSA_FAILURE_MESSAGE)
>   CMake/FindHDF5.cmake:905 (find_package_handle_standard_args)
>   CMakeLists.txt:17 (find_package)