### PR TITLE
Allow setting of fulljones soltabs

### DIFF
--- a/Common/ParameterSet.cc
+++ b/Common/ParameterSet.cc
@@ -40,7 +40,7 @@ ParameterSet* globalParameterSet()
 //
 // Default constructor
 //
-ParameterSet::ParameterSet(KeyCompare::Mode	mode)
+ParameterSet::ParameterSet(KeyCompare::Mode mode)
   : itsSet (new ParameterSetImpl(mode))
 {}
 
@@ -60,13 +60,13 @@ ParameterSet::ParameterSet(const std::string& theFilename, bool caseInsensitive)
 //
 // Construction by reading a parameter file.
 //
-ParameterSet::ParameterSet(const std::string&	theFilename,
-			   KeyCompare::Mode	mode)
+ParameterSet::ParameterSet(const std::string& theFilename,
+         KeyCompare::Mode mode)
   : itsSet (new ParameterSetImpl(theFilename, mode))
 {}
 
-ParameterSet::ParameterSet(const char*	theFilename,
-			   KeyCompare::Mode	mode)
+ParameterSet::ParameterSet(const char*  theFilename,
+         KeyCompare::Mode mode)
   : itsSet (new ParameterSetImpl(std::string(theFilename), mode))
 {}
 
@@ -90,7 +90,7 @@ ParameterSet::operator=(const ParameterSet& that)
 }
 
 //
-//	Destructor
+//  Destructor
 //
 ParameterSet::~ParameterSet()
 {}
@@ -103,7 +103,7 @@ ParameterRecord ParameterSet::getRecord (const std::string& aKey) const
 //
 // operator<<
 //
-std::ostream&	operator<< (std::ostream& os, const ParameterSet &thePS)
+std::ostream& operator<< (std::ostream& os, const ParameterSet &thePS)
 {
   os << *thePS.itsSet;
   return os;

--- a/Common/ParameterSet.h
+++ b/Common/ParameterSet.h
@@ -47,349 +47,349 @@ namespace DP3 {
 class ParameterSet
 {
 public:
-	typedef ParameterSetImpl::iterator			iterator;
-	typedef ParameterSetImpl::const_iterator		const_iterator;
+  typedef ParameterSetImpl::iterator      iterator;
+  typedef ParameterSetImpl::const_iterator    const_iterator;
 
-	// \name Construction and Destruction
-	// A ParameterSet can be constructed as empty collection, can be
-	// read from a file or copied from another collection. 
-	// @{
+  // \name Construction and Destruction
+  // A ParameterSet can be constructed as empty collection, can be
+  // read from a file or copied from another collection. 
+  // @{
 
-	// Create an empty collection. The optional argument \a mode
-	// determines how keys should be compared.
-	explicit ParameterSet(KeyCompare::Mode	mode = KeyCompare::NORMAL);
+  // Create an empty collection. The optional argument \a mode
+  // determines how keys should be compared.
+  explicit ParameterSet(KeyCompare::Mode  mode = KeyCompare::NORMAL);
 
-	// Create an empty collection.
-        // Tell if keys have to be compared case-insenstitive.
-        explicit ParameterSet(bool caseInsensitive);
+  // Create an empty collection.
+  // Tell if keys have to be compared case-insenstitive.
+  explicit ParameterSet(bool caseInsensitive);
 
-	// Destroy the contents.
-	~ParameterSet();
+  // Destroy the contents.
+  ~ParameterSet();
 
-	// Construct a ParameterSet from the contents of \a theFilename. The
-	// optional argument \a mode determines how keys should be compared.
-        // @{
- 	explicit ParameterSet(const std::string& theFilename,
-			      KeyCompare::Mode = KeyCompare::NORMAL);
-        // This one is needed to avoid problems with the bool constructor above.
- 	explicit ParameterSet(const char* theFilename,
-			      KeyCompare::Mode = KeyCompare::NORMAL);
-        // @}
+  // Construct a ParameterSet from the contents of \a theFilename. The
+  // optional argument \a mode determines how keys should be compared.
+  // @{
+  explicit ParameterSet(const std::string& theFilename,
+    KeyCompare::Mode = KeyCompare::NORMAL);
+  // This one is needed to avoid problems with the bool constructor above.
+  explicit ParameterSet(const char* theFilename,
+    KeyCompare::Mode = KeyCompare::NORMAL);
+  // @}
 
-	// Construct a ParameterSet from the contents of \a theFilename.
-        // Tell if keys have to be compared case-insenstitive.
-        explicit ParameterSet(const std::string& theFilename,
-                              bool caseInsensitive);
+  // Construct a ParameterSet from the contents of \a theFilename.
+  // Tell if keys have to be compared case-insenstitive.
+  explicit ParameterSet(const std::string& theFilename,
+                        bool caseInsensitive);
 
 
-	// Copying is allowed.
-	ParameterSet(const ParameterSet& that);
+  // Copying is allowed.
+  ParameterSet(const ParameterSet& that);
 
-	// Copying is allowed.
-	ParameterSet& 	operator=(const ParameterSet& that);
-	//@}
+  // Copying is allowed.
+  ParameterSet&   operator=(const ParameterSet& that);
+  //@}
 
-        // Is the set empty?
-        bool empty() const;
+  // Is the set empty?
+  bool empty() const;
 
-        // Get the number of parameters.
-        int size() const;
+  // Get the number of parameters.
+  int size() const;
 
-	// Iteration.
-	//@{
-	iterator begin();
-	iterator end();
-	const_iterator begin() const;
-	const_iterator end() const;
-	//@}
+  // Iteration.
+  //@{
+  iterator begin();
+  iterator end();
+  const_iterator begin() const;
+  const_iterator end() const;
+  //@}
 
-        // Get the ParameterValue.
-        // @{ 
-        const ParameterValue& get (const std::string& aKey) const;
-        const ParameterValue& operator[] (const std::string& aKey) const;
-        // @}
+  // Get the ParameterValue.
+  // @{ 
+  const ParameterValue& get (const std::string& aKey) const;
+  const ParameterValue& operator[] (const std::string& aKey) const;
+  // @}
 
-	// Key comparison mode.
-	KeyCompare::Mode keyCompareMode() const;
+  // Key comparison mode.
+  KeyCompare::Mode keyCompareMode() const;
 
-	// Clear the set.
-	void clear();
+  // Clear the set.
+  void clear();
 
-	// \name Merging or appending collections
-	// An existing collection can be extended/merged with another collection.
-	// @{
+  // \name Merging or appending collections
+  // An existing collection can be extended/merged with another collection.
+  // @{
 
-	// Adds the Key-Values pair in the given file to the current
-	// collection. Each key will be prefixed with the optional argument \a
-	// thePrefix.
-        // <br> Note that no dot is added to the prefix.
-	void	adoptFile      (const std::string&               theFilename,
-				const std::string&               thePrefix = "");
+  // Adds the Key-Values pair in the given file to the current
+  // collection. Each key will be prefixed with the optional argument \a
+  // thePrefix.
+  // <br> Note that no dot is added to the prefix.
+  void  adoptFile      (const std::string&               theFilename,
+        const std::string&               thePrefix = "");
 
-	// Adds the Key-Values pair in the given buffer to the current
-	// collection. Each key will be prefixed with the optional argument \a
-	// thePrefix.
-        // <br> Note that no dot is added to the prefix.
-	void	adoptBuffer    (const std::string&               theBuffer,
-				const std::string&               thePrefix = "");
+  // Adds the Key-Values pair in the given buffer to the current
+  // collection. Each key will be prefixed with the optional argument \a
+  // thePrefix.
+  // <br> Note that no dot is added to the prefix.
+  void  adoptBuffer    (const std::string&               theBuffer,
+        const std::string&               thePrefix = "");
 
-	// Adds the Key-Values pair in the given collection to the current 
-	// collection. Each key will be prefixed with the optional argument \a
-	// thePrefix.
-        // <br> Note that no dot is added to the prefix.
-        // <br>If theCollection is this collection, nothing will be done.
-	void	adoptCollection(const ParameterSet&         theCollection,
-				const std::string&               thePrefix = "");
+  // Adds the Key-Values pair in the given collection to the current 
+  // collection. Each key will be prefixed with the optional argument \a
+  // thePrefix.
+  // <br> Note that no dot is added to the prefix.
+  // <br>If theCollection is this collection, nothing will be done.
+  void  adoptCollection(const ParameterSet&         theCollection,
+        const std::string&               thePrefix = "");
 
         // Adds the Key-Values pairs in the argument list.
         // It ignores arguments not having the Key=Value syntax.
         void    adoptArgv      (int nr, char const * const argv[]);
-	// @}
+  // @}
 
 
-	// \name Saving the collection
-	// The map of key-value pair can be saved in a file or a string.
-	// @{
+  // \name Saving the collection
+  // The map of key-value pair can be saved in a file or a string.
+  // @{
 
-	// Writes the Key-Values pair from the current ParCollection to the file.
-	void	writeFile   (const std::string& theFilename, bool append = false) const;
+  // Writes the Key-Values pair from the current ParCollection to the file.
+  void  writeFile   (const std::string& theFilename, bool append = false) const;
 
-	// Writes the Key-Values pair from the current ParCollection to the 
-	// string buffer.
-	void	writeBuffer (      std::string& theBuffer) const;
+  // Writes the Key-Values pair from the current ParCollection to the 
+  // string buffer.
+  void  writeBuffer (      std::string& theBuffer) const;
 
-	// Writes the Key-Values pair from the current ParCollection to the 
-	// output stream.
-	void	writeStream (      std::ostream& os) const;
-	//@}
+  // Writes the Key-Values pair from the current ParCollection to the 
+  // output stream.
+  void  writeStream (      std::ostream& os) const;
+  //@}
 
-	// \name Handle subsets
-	// A subset from the current collection can be made based on the prefix
-	// of the keys in the collection.
-	// @{
+  // \name Handle subsets
+  // A subset from the current collection can be made based on the prefix
+  // of the keys in the collection.
+  // @{
 
-	// Creates a subset from the current ParameterSet containing all the 
-	// parameters that start with the given baseKey. The baseKey is cut off 
-	// from the Keynames in the created subset, the optional prefix is put
-	// before all keys in the subset.
+  // Creates a subset from the current ParameterSet containing all the 
+  // parameters that start with the given baseKey. The baseKey is cut off 
+  // from the Keynames in the created subset, the optional prefix is put
+  // before all keys in the subset.
         // <br>It is important to note that no dot is added to the prefix, so
         // it has to be given explicitly. So when giving a prefix like "pre",
         // a key "pre.key" gets ".key" and "prefix.key" get "fix.key".
-	ParameterSet	makeSubset(const std::string& baseKey,
-								   const std::string& prefix = "") const;
+  ParameterSet  makeSubset(const std::string& baseKey,
+                  const std::string& prefix = "") const;
 
-	// Subtract a subset from the current ParameterSet. Every parameter
-	// whose key starts with the given name will be removed from the
-	// ParameterSet.
+  // Subtract a subset from the current ParameterSet. Every parameter
+  // whose key starts with the given name will be removed from the
+  // ParameterSet.
         // <br> Similarly to makeSubset, no dot is added to the prefix.
-	void	subtractSubset(const std::string& fullPrefix);
-	// @}
+  void  subtractSubset(const std::string& fullPrefix);
+  // @}
 
-	
-	// \name Handling single key-value pairs
-	// Single key-value pairs can ofcourse be added, replaced or removed from 
-	// a collection.
-	// @{
+  
+  // \name Handling single key-value pairs
+  // Single key-value pairs can ofcourse be added, replaced or removed from 
+  // a collection.
+  // @{
 
-	// Add the given pair to the collection. When the \c aKey already exist 
-	// in the collection an exception is thrown.
-	void	add    (const std::string& aKey, const std::string& aValue);
-	void	add    (const KVpair& aPair);
+  // Add the given pair to the collection. When the \c aKey already exist 
+  // in the collection an exception is thrown.
+  void  add    (const std::string& aKey, const std::string& aValue);
+  void  add    (const KVpair& aPair);
 
-	// Replaces the given pair in the collection. If \c aKey does not exist in
-	// the collection the pair is just added to the collection.
-	void	replace(const std::string& aKey, const std::string& aValue);
-	void	replace(const KVpair& aPair);
+  // Replaces the given pair in the collection. If \c aKey does not exist in
+  // the collection the pair is just added to the collection.
+  void  replace(const std::string& aKey, const std::string& aValue);
+  void  replace(const KVpair& aPair);
 
-	// Removes the pair with the given key. Removing a non-existing key is ok.
-	void	remove (const std::string& aKey);
-	// @}
+  // Removes the pair with the given key. Removing a non-existing key is ok.
+  void  remove (const std::string& aKey);
+  // @}
 
-	// \name Searching and retrieving
-	// The following functions support searching the collection for existance
-	// of given keys an the retrieval of the corresponding value. In the getXxx
-	// retrieve functions the stored string-value is converted to the wanted
-	// type.
-	// @{
+  // \name Searching and retrieving
+  // The following functions support searching the collection for existance
+  // of given keys an the retrieval of the corresponding value. In the getXxx
+  // retrieve functions the stored string-value is converted to the wanted
+  // type.
+  // @{
 
-        // Find a key.
-        iterator find (const std::string& searchKey);
-        const_iterator find (const std::string& searchKey) const;
+  // Find a key.
+  iterator find (const std::string& searchKey);
+  const_iterator find (const std::string& searchKey) const;
 
-	// Checks if the given Key is defined in the ParameterSet.
-	bool	isDefined (const std::string& searchKey) const;
+  // Checks if the given Key is defined in the ParameterSet.
+  bool  isDefined (const std::string& searchKey) const;
 
-	// Searches for a module whose name end in the given modulename.
-	// e.g: a.b.c.d.param=xxxx --> locateModule(d)-->a.b.c.
-	std::string	locateModule  (const std::string&	shortName) const;
+  // Searches for a module whose name end in the given modulename.
+  // e.g: a.b.c.d.param=xxxx --> locateModule(d)-->a.b.c.
+  std::string locateModule  (const std::string& shortName) const;
 
-	// Searches the module name or module hierarchy and returns its fullposition.
-	// e.g: a.b.c.d.param=xxxx --> fullModuleName(d)-->a.b.c.d
-	// e.g: a.b.c.d.param=xxxx --> fullModuleName(b.c)-->a.b.c
-	std::string	fullModuleName(const std::string&	shortName) const;
+  // Searches the module name or module hierarchy and returns its fullposition.
+  // e.g: a.b.c.d.param=xxxx --> fullModuleName(d)-->a.b.c.d
+  // e.g: a.b.c.d.param=xxxx --> fullModuleName(b.c)-->a.b.c
+  std::string fullModuleName(const std::string& shortName) const;
 
-	// Return the value of the key as a vector of values.
+  // Return the value of the key as a vector of values.
         // This can only be done if the value is enclosed in square brackets.
         std::vector<ParameterValue> getVector (const std::string& aKey) const;
 
-	// Return the value of the key as a parameter record.
+  // Return the value of the key as a parameter record.
         // This can only be done if the value is enclosed in curly braces.
         ParameterRecord getRecord (const std::string& aKey) const;
 
-	// Return scalar value.
-	// @{
-	bool	getBool  (const std::string& aKey) const;
-        bool	getBool  (const std::string& aKey, bool aValue) const;
-	int	getInt   (const std::string& aKey) const;
-        int	getInt   (const std::string& aKey, int aValue) const;
-	uint	getUint  (const std::string& aKey) const;
-        uint	getUint  (const std::string& aKey, uint aValue) const;
-	int16_t	getInt16 (const std::string& aKey) const;
-        int16_t	getInt16 (const std::string& aKey, int16_t aValue) const;
-	uint16_t	getUint16(const std::string& aKey) const;
-        uint16_t	getUint16(const std::string& aKey, uint16_t aValue) const;
-	int32_t	getInt32 (const std::string& aKey) const;
-        int32_t	getInt32 (const std::string& aKey, int32_t aValue) const;
-	uint32_t	getUint32(const std::string& aKey) const;
-        uint32_t	getUint32(const std::string& aKey, uint32_t aValue) const;
-	int64_t	getInt64 (const std::string& aKey) const;
-        int64_t	getInt64 (const std::string& aKey, int64_t aValue) const;
-	uint64_t	getUint64(const std::string& aKey) const;
-        uint64_t	getUint64(const std::string& aKey, uint64_t aValue) const;
-	float	getFloat (const std::string& aKey) const;
-        float	getFloat (const std::string& aKey, float aValue) const;
-	double	getDouble(const std::string& aKey) const;
-        double	getDouble(const std::string& aKey, double aValue) const;
-	std::string	getString(const std::string& aKey) const;
-        std::string	getString(const std::string& aKey, const std::string& aValue) const;
-	// Returns the value as a time value (seconds since 1970).
-	// @{
-	time_t	getTime  (const std::string& aKey) const;
-        time_t	getTime  (const std::string& aKey, const time_t& aValue) const;
-	// @}
-	// @}
+  // Return scalar value.
+  // @{
+  bool  getBool  (const std::string& aKey) const;
+  bool  getBool  (const std::string& aKey, bool aValue) const;
+  int getInt   (const std::string& aKey) const;
+  int getInt   (const std::string& aKey, int aValue) const;
+  uint  getUint  (const std::string& aKey) const;
+  uint  getUint  (const std::string& aKey, uint aValue) const;
+  int16_t getInt16 (const std::string& aKey) const;
+  int16_t getInt16 (const std::string& aKey, int16_t aValue) const;
+  uint16_t  getUint16(const std::string& aKey) const;
+  uint16_t  getUint16(const std::string& aKey, uint16_t aValue) const;
+  int32_t getInt32 (const std::string& aKey) const;
+  int32_t getInt32 (const std::string& aKey, int32_t aValue) const;
+  uint32_t  getUint32(const std::string& aKey) const;
+  uint32_t  getUint32(const std::string& aKey, uint32_t aValue) const;
+  int64_t getInt64 (const std::string& aKey) const;
+  int64_t getInt64 (const std::string& aKey, int64_t aValue) const;
+  uint64_t  getUint64(const std::string& aKey) const;
+  uint64_t  getUint64(const std::string& aKey, uint64_t aValue) const;
+  float getFloat (const std::string& aKey) const;
+  float getFloat (const std::string& aKey, float aValue) const;
+  double  getDouble(const std::string& aKey) const;
+  double  getDouble(const std::string& aKey, double aValue) const;
+  std::string getString(const std::string& aKey) const;
+  std::string getString(const std::string& aKey, const std::string& aValue) const;
+  // Returns the value as a time value (seconds since 1970).
+  // @{
+  time_t  getTime  (const std::string& aKey) const;
+  time_t  getTime  (const std::string& aKey, const time_t& aValue) const;
+  // @}
+  // @}
 
-	// Return vector of values.
-	// @{
-        std::vector<bool>	getBoolVector  (const std::string& aKey,
+  // Return vector of values.
+  // @{
+  std::vector<bool> getBoolVector  (const std::string& aKey,
+                                  bool expandable = false) const;
+  std::vector<bool> getBoolVector  (const std::string& aKey,
+                                  const std::vector<bool>& aValue,
+                                  bool expandable = false) const;
+  std::vector<int>  getIntVector   (const std::string& aKey,
+                                  bool expandable = false) const;
+  std::vector<int>  getIntVector   (const std::string& aKey,
+                                  const std::vector<int>& aValue,
+                                  bool expandable = false) const;
+  std::vector<uint> getUintVector  (const std::string& aKey,
+                                  bool expandable = false) const;
+  std::vector<uint> getUintVector  (const std::string& aKey,
+                                  const std::vector<uint>& aValue,
+                                  bool expandable = false) const;
+  std::vector<int16_t>  getInt16Vector (const std::string& aKey,
+                                  bool expandable = false) const;
+  std::vector<int16_t>  getInt16Vector (const std::string& aKey,
+                                  const std::vector<int16_t>& aValue,
+                                  bool expandable = false) const;
+  std::vector<uint16_t> getUint16Vector(const std::string& aKey,
+                                  bool expandable = false) const;
+  std::vector<uint16_t> getUint16Vector(const std::string& aKey,
+                                  const std::vector<uint16_t>& aValue,
+                                  bool expandable = false) const;
+  std::vector<int32_t>  getInt32Vector (const std::string& aKey,
+                                  bool expandable = false) const;
+  std::vector<int32_t>  getInt32Vector (const std::string& aKey,
+                                  const std::vector<int32_t>& aValue,
+                                  bool expandable = false) const;
+  std::vector<uint32_t> getUint32Vector(const std::string& aKey,
                                         bool expandable = false) const;
-        std::vector<bool>	getBoolVector  (const std::string& aKey,
-                                        const std::vector<bool>& aValue,
-                                        bool expandable = false) const;
-        std::vector<int>	getIntVector   (const std::string& aKey,
-                                        bool expandable = false) const;
-        std::vector<int>	getIntVector   (const std::string& aKey,
-                                        const std::vector<int>& aValue,
-                                        bool expandable = false) const;
-        std::vector<uint>	getUintVector  (const std::string& aKey,
-                                        bool expandable = false) const;
-        std::vector<uint>	getUintVector  (const std::string& aKey,
-                                        const std::vector<uint>& aValue,
-                                        bool expandable = false) const;
-        std::vector<int16_t>	getInt16Vector (const std::string& aKey,
-                                        bool expandable = false) const;
-        std::vector<int16_t>	getInt16Vector (const std::string& aKey,
-                                        const std::vector<int16_t>& aValue,
-                                        bool expandable = false) const;
-        std::vector<uint16_t>	getUint16Vector(const std::string& aKey,
-                                        bool expandable = false) const;
-        std::vector<uint16_t>	getUint16Vector(const std::string& aKey,
-                                        const std::vector<uint16_t>& aValue,
-                                        bool expandable = false) const;
-        std::vector<int32_t>	getInt32Vector (const std::string& aKey,
-                                        bool expandable = false) const;
-        std::vector<int32_t>	getInt32Vector (const std::string& aKey,
-                                        const std::vector<int32_t>& aValue,
-                                        bool expandable = false) const;
-	std::vector<uint32_t>	getUint32Vector(const std::string& aKey,
-                                        bool expandable = false) const;
-        std::vector<uint32_t>	getUint32Vector(const std::string& aKey,
+  std::vector<uint32_t> getUint32Vector(const std::string& aKey,
                                         const std::vector<uint32_t>& aValue,
                                         bool expandable = false) const;
-	std::vector<int64_t>	getInt64Vector (const std::string& aKey,
+  std::vector<int64_t>  getInt64Vector (const std::string& aKey,
                                         bool expandable = false) const;
-        std::vector<int64_t>	getInt64Vector (const std::string& aKey,
+  std::vector<int64_t>  getInt64Vector (const std::string& aKey,
                                         const std::vector<int64_t>& aValue,
                                         bool expandable = false) const;
-	std::vector<uint64_t>	getUint64Vector(const std::string& aKey,
+  std::vector<uint64_t> getUint64Vector(const std::string& aKey,
                                         bool expandable = false) const;
-        std::vector<uint64_t>	getUint64Vector(const std::string& aKey,
+  std::vector<uint64_t> getUint64Vector(const std::string& aKey,
                                         const std::vector<uint64_t>& aValue,
                                         bool expandable = false) const;
-	std::vector<float>	getFloatVector (const std::string& aKey,
+  std::vector<float>  getFloatVector (const std::string& aKey,
                                         bool expandable = false) const;
-        std::vector<float>	getFloatVector (const std::string& aKey,
+  std::vector<float>  getFloatVector (const std::string& aKey,
                                         const std::vector<float>& aValue,
                                         bool expandable = false) const;
-	std::vector<double>	getDoubleVector(const std::string& aKey,
+  std::vector<double> getDoubleVector(const std::string& aKey,
                                         bool expandable = false) const;
-        std::vector<double>	getDoubleVector(const std::string& aKey,
+  std::vector<double> getDoubleVector(const std::string& aKey,
                                         const std::vector<double>& aValue,
                                         bool expandable = false) const;
-	std::vector<std::string>	getStringVector(const std::string& aKey,
+  std::vector<std::string>  getStringVector(const std::string& aKey,
                                         bool expandable = false) const;
-        std::vector<std::string>	getStringVector(const std::string& aKey,
+  std::vector<std::string>  getStringVector(const std::string& aKey,
                                         const std::vector<std::string>& aValue,
                                         bool expandable = false) const;
-	std::vector<time_t>	getTimeVector  (const std::string& aKey,
+  std::vector<time_t> getTimeVector  (const std::string& aKey,
                                         bool expandable = false) const;
-        std::vector<time_t>	getTimeVector  (const std::string& aKey,
+  std::vector<time_t> getTimeVector  (const std::string& aKey,
                                         const std::vector<time_t>& aValue,
                                         bool expandable = false) const;
-	// @}
+  // @}
 
-	// @}
+  // @}
 
         // Get all unused parameter names, thus the names of parameters
         // that have not been asked for.
         std::vector<std::string> unusedKeys() const;
 
-	// \name Printing
-	// Mostly for debug purposes the collection can be printed.
-	// @{
+  // \name Printing
+  // Mostly for debug purposes the collection can be printed.
+  // @{
 
-	// Allow printing the whole parameter collection.
-	friend std::ostream& operator<<(std::ostream& os, const ParameterSet &thePS);
-	// @}
+  // Allow printing the whole parameter collection.
+  friend std::ostream& operator<<(std::ostream& os, const ParameterSet &thePS);
+  // @}
 
 private:
-	// Construct from an existing impl object.
+  // Construct from an existing impl object.
         explicit ParameterSet (const std::shared_ptr<ParameterSetImpl>& set)
-	  { itsSet = set; }
+    { itsSet = set; }
 
         std::shared_ptr<ParameterSetImpl> itsSet;
 };
 
 
 // Make one instance of the parameterSet globally accessable.
-ParameterSet* 	globalParameterSet();
+ParameterSet*   globalParameterSet();
 
 //#
 //# ---------- inline functions ----------
 //#
 inline bool ParameterSet::empty() const
 {
-	return itsSet->empty();
+  return itsSet->empty();
 }
 inline int ParameterSet::size() const
 {
-	return itsSet->size();
+  return itsSet->size();
 }
-inline ParameterSet::iterator	ParameterSet::begin      ()
+inline ParameterSet::iterator ParameterSet::begin      ()
 {
-	return itsSet->begin();
+  return itsSet->begin();
 }
-inline ParameterSet::iterator	ParameterSet::end      ()
+inline ParameterSet::iterator ParameterSet::end      ()
 {
-	return itsSet->end();
+  return itsSet->end();
 }
-inline ParameterSet::const_iterator	ParameterSet::begin      () const
+inline ParameterSet::const_iterator ParameterSet::begin      () const
 {
-	return itsSet->begin();
+  return itsSet->begin();
 }
-inline ParameterSet::const_iterator	ParameterSet::end      () const
+inline ParameterSet::const_iterator ParameterSet::end      () const
 {
-	return itsSet->end();
+  return itsSet->end();
 }
 
 inline const ParameterValue& ParameterSet::get (const std::string& aKey) const
@@ -401,108 +401,108 @@ inline const ParameterValue& ParameterSet::operator[] (const std::string& aKey) 
         return itsSet->get (aKey);
 }
 
-inline KeyCompare::Mode	ParameterSet::keyCompareMode	() const
+inline KeyCompare::Mode ParameterSet::keyCompareMode  () const
 {
-	return itsSet->keyCompareMode();
+  return itsSet->keyCompareMode();
 }
 
-inline void	ParameterSet::clear()
+inline void ParameterSet::clear()
 {
-	itsSet->clear();
+  itsSet->clear();
 }
 
-inline void	ParameterSet::adoptFile	(const std::string& theFilename, const std::string& thePrefix)
+inline void ParameterSet::adoptFile (const std::string& theFilename, const std::string& thePrefix)
 {
-	itsSet->adoptFile (theFilename, thePrefix);
+  itsSet->adoptFile (theFilename, thePrefix);
 }
 
-inline void	ParameterSet::adoptBuffer	(const std::string& theBuffer, const std::string& thePrefix)
+inline void ParameterSet::adoptBuffer (const std::string& theBuffer, const std::string& thePrefix)
 {
-	itsSet->adoptBuffer (theBuffer, thePrefix);
+  itsSet->adoptBuffer (theBuffer, thePrefix);
 }
 
-inline void	ParameterSet::adoptCollection	(const ParameterSet& theCollection, const std::string& thePrefix)
+inline void ParameterSet::adoptCollection (const ParameterSet& theCollection, const std::string& thePrefix)
 {
-	itsSet->adoptCollection (*theCollection.itsSet, thePrefix);
+  itsSet->adoptCollection (*theCollection.itsSet, thePrefix);
 }
 
-  inline void	ParameterSet::adoptArgv  	(int nr, const char * const argv[])
+  inline void ParameterSet::adoptArgv   (int nr, const char * const argv[])
 {
         itsSet->adoptArgv (nr, argv);
 }
 
-inline void	ParameterSet::writeFile   (const std::string& theFilename, bool append) const
+inline void ParameterSet::writeFile   (const std::string& theFilename, bool append) const
 {
-	itsSet->writeFile (theFilename, append);
+  itsSet->writeFile (theFilename, append);
 }
 
-inline void	ParameterSet::writeBuffer (      std::string& theBuffer) const
+inline void ParameterSet::writeBuffer (      std::string& theBuffer) const
 {
-	itsSet->writeBuffer (theBuffer);
+  itsSet->writeBuffer (theBuffer);
 }
 
-inline void	ParameterSet::writeStream (      std::ostream& os) const
+inline void ParameterSet::writeStream (      std::ostream& os) const
 {
-	itsSet->writeStream (os);
+  itsSet->writeStream (os);
 }
 
-inline ParameterSet	ParameterSet::makeSubset(const std::string& baseKey,
-								   const std::string& prefix) const
+inline ParameterSet ParameterSet::makeSubset(const std::string& baseKey,
+                   const std::string& prefix) const
 {
-	return ParameterSet (itsSet->makeSubset(baseKey, prefix));
+  return ParameterSet (itsSet->makeSubset(baseKey, prefix));
 }
 
-inline void	ParameterSet::subtractSubset(const std::string& fullPrefix)
+inline void ParameterSet::subtractSubset(const std::string& fullPrefix)
 {
-	itsSet->subtractSubset(fullPrefix);
+  itsSet->subtractSubset(fullPrefix);
 }
 
-inline void	ParameterSet::add    (const std::string& aKey, const std::string& aValue)
+inline void ParameterSet::add    (const std::string& aKey, const std::string& aValue)
 {
         itsSet->add (aKey, ParameterValue(aValue, false));
 }
-inline void	ParameterSet::add    (const KVpair& aPair)
+inline void ParameterSet::add    (const KVpair& aPair)
 {
         add (aPair.first, aPair.second);
 }
 
-inline void	ParameterSet::replace(const std::string& aKey, const std::string& aValue)
+inline void ParameterSet::replace(const std::string& aKey, const std::string& aValue)
 {
         itsSet->replace (aKey, ParameterValue(aValue, false));
 }
-inline void	ParameterSet::replace(const KVpair& aPair)
+inline void ParameterSet::replace(const KVpair& aPair)
 {
         replace (aPair.first, aPair.second);
 }
 
-inline void	ParameterSet::remove (const std::string& aKey)
+inline void ParameterSet::remove (const std::string& aKey)
 {
-	itsSet->remove (aKey);
+  itsSet->remove (aKey);
 }
 
 inline ParameterSet::iterator ParameterSet::find (const std::string& searchKey)
 {
-	return itsSet->find (searchKey);
+  return itsSet->find (searchKey);
 }
 
 inline ParameterSet::const_iterator ParameterSet::find (const std::string& searchKey) const
 {
-	return itsSet->find (searchKey);
+  return itsSet->find (searchKey);
 }
 
-inline bool	ParameterSet::isDefined (const std::string& searchKey) const
+inline bool ParameterSet::isDefined (const std::string& searchKey) const
 {
-	return itsSet->isDefined (searchKey);
+  return itsSet->isDefined (searchKey);
 }
 
-inline std::string	ParameterSet::locateModule(const std::string&	shortName) const
+inline std::string  ParameterSet::locateModule(const std::string& shortName) const
 {
-	return (itsSet->locateModule(shortName));
+  return (itsSet->locateModule(shortName));
 }
 
-inline std::string	ParameterSet::fullModuleName(const std::string&	shortName) const
+inline std::string  ParameterSet::fullModuleName(const std::string& shortName) const
 {
-	return (itsSet->fullModuleName(shortName));
+  return (itsSet->fullModuleName(shortName));
 }
 
 inline std::vector<ParameterValue> ParameterSet::getVector (const std::string& aKey) const
@@ -510,170 +510,170 @@ inline std::vector<ParameterValue> ParameterSet::getVector (const std::string& a
         return get(aKey).getVector();
 }
 
-//#	getBool(key)
+//# getBool(key)
 inline bool ParameterSet::getBool(const std::string& aKey) const
 {
-	return itsSet->getBool(aKey);
+  return itsSet->getBool(aKey);
 }
 
-//#	getBool(key, value)
+//# getBool(key, value)
 inline bool ParameterSet::getBool(const std::string& aKey, bool aValue) const
 {
         return itsSet->getBool(aKey, aValue);
 }
 
-//#	getInt(key)
+//# getInt(key)
 inline int ParameterSet::getInt(const std::string& aKey) const
 {
-	return itsSet->getInt(aKey);
+  return itsSet->getInt(aKey);
 }
 
-//#	getInt(key, value)
+//# getInt(key, value)
 inline int ParameterSet::getInt(const std::string& aKey, int aValue) const
 {
         return itsSet->getInt(aKey, aValue);
 }
 
-//#	getUint(key)
+//# getUint(key)
 inline uint ParameterSet::getUint(const std::string& aKey) const
 {
-	return itsSet->getUint(aKey);
+  return itsSet->getUint(aKey);
 }
 
-//#	getUint(key, value)
+//# getUint(key, value)
 inline uint ParameterSet::getUint(const std::string& aKey, uint aValue) const
 {
         return itsSet->getUint(aKey, aValue);
 }
 
-//#	getInt16(key)
+//# getInt16(key)
 inline int16_t ParameterSet::getInt16(const std::string& aKey) const
 {
-	return itsSet->getInt16(aKey);
+  return itsSet->getInt16(aKey);
 }
 
-//#	getInt16(key, value)
+//# getInt16(key, value)
 inline int16_t ParameterSet::getInt16(const std::string& aKey, int16_t aValue) const
 {
         return itsSet->getInt16(aKey, aValue);
 }
 
-//#	getUint16(key)
+//# getUint16(key)
 inline uint16_t ParameterSet::getUint16(const std::string& aKey) const
 {
-	return itsSet->getUint16(aKey);
+  return itsSet->getUint16(aKey);
 }
 
-//#	getUint16(key, value)
+//# getUint16(key, value)
 inline uint16_t ParameterSet::getUint16(const std::string& aKey, uint16_t aValue) const
 {
         return itsSet->getUint16(aKey, aValue);
 }
 
-//#	getInt32(key)
+//# getInt32(key)
 inline int32_t ParameterSet::getInt32(const std::string& aKey) const
 {
-	return itsSet->getInt32(aKey);
+  return itsSet->getInt32(aKey);
 }
 
-//#	getInt32(key, value)
+//# getInt32(key, value)
 inline int32_t ParameterSet::getInt32(const std::string& aKey, int32_t aValue) const
 {
         return itsSet->getInt32(aKey, aValue);
 }
 
-//#	getUint32(key)
+//# getUint32(key)
 inline uint32_t ParameterSet::getUint32(const std::string& aKey) const
 {
-	return itsSet->getUint32(aKey);
+  return itsSet->getUint32(aKey);
 }
 
-//#	getUint32(key, value)
+//# getUint32(key, value)
 inline uint32_t ParameterSet::getUint32(const std::string& aKey, uint32_t aValue) const
 {
         return itsSet->getUint32(aKey, aValue);
 }
 
-//#	getInt64(key)
+//# getInt64(key)
 inline int64_t ParameterSet::getInt64(const std::string& aKey) const
 {
-	return itsSet->getInt64(aKey);
+  return itsSet->getInt64(aKey);
 }
 
-//#	getInt64(key, value)
+//# getInt64(key, value)
 inline int64_t ParameterSet::getInt64(const std::string& aKey, int64_t aValue) const
 {
         return itsSet->getInt64(aKey, aValue);
 }
 
-//#	getUint64(key)
+//# getUint64(key)
 inline uint64_t ParameterSet::getUint64(const std::string& aKey) const
 {
-	return itsSet->getUint64(aKey);
+  return itsSet->getUint64(aKey);
 }
 
-//#	getUint64(key, value)
+//# getUint64(key, value)
 inline uint64_t ParameterSet::getUint64(const std::string& aKey, uint64_t aValue) const
 {
         return itsSet->getUint64(aKey, aValue);
 }
 
-//#	getFloat(key)
+//# getFloat(key)
 inline float ParameterSet::getFloat (const std::string& aKey) const
 {
-	return itsSet->getFloat(aKey);
+  return itsSet->getFloat(aKey);
 }
 
-//#	getFloat(key, value)
+//# getFloat(key, value)
 inline float ParameterSet::getFloat (const std::string& aKey, float aValue) const
 {
         return itsSet->getFloat(aKey, aValue);
 }
 
-//#	getDouble(key)
+//# getDouble(key)
 inline double ParameterSet::getDouble(const std::string& aKey) const
 {
-	return itsSet->getDouble(aKey);
+  return itsSet->getDouble(aKey);
 }
 
-//#	getDouble(key, value)
+//# getDouble(key, value)
 inline double ParameterSet::getDouble(const std::string& aKey, double aValue) const
 {
         return itsSet->getDouble(aKey, aValue);
 }
 
-//#	getString(key)
+//# getString(key)
 inline std::string ParameterSet::getString(const std::string& aKey) const
 {
-	return itsSet->getString(aKey);
+  return itsSet->getString(aKey);
 }
 
-//#	getString(key, value)
+//# getString(key, value)
 inline std::string ParameterSet::getString(const std::string& aKey, const std::string& aValue) const
 {
         return itsSet->getString(aKey, aValue);
 }
 
-//#	getTime(key)
+//# getTime(key)
 inline time_t ParameterSet::getTime(const std::string& aKey) const
 {
-	return itsSet->getTime(aKey);
+  return itsSet->getTime(aKey);
 }
 
-//#	getTime(key, value)
+//# getTime(key, value)
 inline time_t ParameterSet::getTime(const std::string& aKey, const time_t& aValue) const
 {
         return itsSet->getTime(aKey, aValue);
 }
 
-//#	getBoolVector(key)
+//# getBoolVector(key)
 inline std::vector<bool> ParameterSet::getBoolVector(const std::string& aKey,
                                                 bool expandable) const
 {
         return itsSet->getBoolVector(aKey, expandable);
 }
 
-//#	getBoolVector(key, value)
+//# getBoolVector(key, value)
 inline std::vector<bool> ParameterSet::getBoolVector(const std::string& aKey,
                                                 const std::vector<bool>& aValue,
                                                 bool expandable) const
@@ -681,14 +681,14 @@ inline std::vector<bool> ParameterSet::getBoolVector(const std::string& aKey,
         return itsSet->getBoolVector(aKey, aValue, expandable);
 }
 
-//#	getIntVector(key)
+//# getIntVector(key)
 inline std::vector<int> ParameterSet::getIntVector(const std::string& aKey,
                                               bool expandable) const
 {
         return itsSet->getIntVector(aKey, expandable);
 }
 
-//#	getIntVector(key, value)
+//# getIntVector(key, value)
 inline std::vector<int> ParameterSet::getIntVector(const std::string& aKey,
                                               const std::vector<int>& aValue,
                                               bool expandable) const
@@ -696,14 +696,14 @@ inline std::vector<int> ParameterSet::getIntVector(const std::string& aKey,
         return itsSet->getIntVector(aKey, aValue, expandable);
 }
 
-//#	getUintVector(key)
+//# getUintVector(key)
 inline std::vector<uint> ParameterSet::getUintVector(const std::string& aKey,
                                                 bool expandable) const
 {
         return itsSet->getUintVector(aKey, expandable);
 }
 
-//#	getUintVector(key, value)
+//# getUintVector(key, value)
 inline std::vector<uint> ParameterSet::getUintVector(const std::string& aKey,
                                                 const std::vector<uint>& aValue,
                                                 bool expandable) const
@@ -711,29 +711,29 @@ inline std::vector<uint> ParameterSet::getUintVector(const std::string& aKey,
         return itsSet->getUintVector(aKey, aValue, expandable);
 }
 
-//#	getInt16Vector(key)
+//# getInt16Vector(key)
 inline std::vector<int16_t> ParameterSet::getInt16Vector(const std::string& aKey,
                                                   bool expandable) const
 {
-	return itsSet->getInt16Vector(aKey, expandable);
+  return itsSet->getInt16Vector(aKey, expandable);
 }
 
-//#	getInt16Vector(key, value)
+//# getInt16Vector(key, value)
 inline std::vector<int16_t> ParameterSet::getInt16Vector(const std::string& aKey,
                                                   const std::vector<int16_t>& aValue,
                                                   bool expandable) const
 {
-	return itsSet->getInt16Vector(aKey, aValue, expandable);
+  return itsSet->getInt16Vector(aKey, aValue, expandable);
 }
 
-//#	getUint16Vector(key)
+//# getUint16Vector(key)
 inline std::vector<uint16_t> ParameterSet::getUint16Vector(const std::string& aKey,
                                                     bool expandable) const
 {
-	return itsSet->getUint16Vector(aKey, expandable);
+  return itsSet->getUint16Vector(aKey, expandable);
 }
 
-//#	getUint16Vector(key, value)
+//# getUint16Vector(key, value)
 inline std::vector<uint16_t> ParameterSet::getUint16Vector(const std::string& aKey,
                                                     const std::vector<uint16_t>& aValue,
                                                     bool expandable) const
@@ -741,29 +741,29 @@ inline std::vector<uint16_t> ParameterSet::getUint16Vector(const std::string& aK
         return itsSet->getUint16Vector(aKey, aValue, expandable);
 }
 
-//#	getInt32Vector(key)
+//# getInt32Vector(key)
 inline std::vector<int32_t> ParameterSet::getInt32Vector(const std::string& aKey,
                                                   bool expandable) const
 {
-	return itsSet->getInt32Vector(aKey, expandable);
+  return itsSet->getInt32Vector(aKey, expandable);
 }
 
-//#	getInt32Vector(key, value)
+//# getInt32Vector(key, value)
 inline std::vector<int32_t> ParameterSet::getInt32Vector(const std::string& aKey,
                                                   const std::vector<int32_t>& aValue,
                                                   bool expandable) const
 {
-	return itsSet->getInt32Vector(aKey, aValue, expandable);
+  return itsSet->getInt32Vector(aKey, aValue, expandable);
 }
 
-//#	getUint32Vector(key)
+//# getUint32Vector(key)
 inline std::vector<uint32_t> ParameterSet::getUint32Vector(const std::string& aKey,
                                                     bool expandable) const
 {
-	return itsSet->getUint32Vector(aKey, expandable);
+  return itsSet->getUint32Vector(aKey, expandable);
 }
 
-//#	getUint32Vector(key, value)
+//# getUint32Vector(key, value)
 inline std::vector<uint32_t> ParameterSet::getUint32Vector(const std::string& aKey,
                                                     const std::vector<uint32_t>& aValue,
                                                     bool expandable) const
@@ -771,29 +771,29 @@ inline std::vector<uint32_t> ParameterSet::getUint32Vector(const std::string& aK
         return itsSet->getUint32Vector(aKey, aValue, expandable);
 }
 
-//#	getInt64Vector(key)
+//# getInt64Vector(key)
 inline std::vector<int64_t> ParameterSet::getInt64Vector(const std::string& aKey,
                                                   bool expandable) const
 {
-	return itsSet->getInt64Vector(aKey, expandable);
+  return itsSet->getInt64Vector(aKey, expandable);
 }
 
-//#	getInt64Vector(key, value)
+//# getInt64Vector(key, value)
 inline std::vector<int64_t> ParameterSet::getInt64Vector(const std::string& aKey,
                                                   const std::vector<int64_t>& aValue,
                                                   bool expandable) const
 {
-	return itsSet->getInt64Vector(aKey, aValue, expandable);
+  return itsSet->getInt64Vector(aKey, aValue, expandable);
 }
 
-//#	getUint64Vector(key)
+//# getUint64Vector(key)
 inline std::vector<uint64_t> ParameterSet::getUint64Vector(const std::string& aKey,
                                                     bool expandable) const
 {
-	return itsSet->getUint64Vector(aKey, expandable);
+  return itsSet->getUint64Vector(aKey, expandable);
 }
 
-//#	getUint64Vector(key, value)
+//# getUint64Vector(key, value)
 inline std::vector<uint64_t> ParameterSet::getUint64Vector(const std::string& aKey,
                                                     const std::vector<uint64_t>& aValue,
                                                     bool expandable) const
@@ -801,14 +801,14 @@ inline std::vector<uint64_t> ParameterSet::getUint64Vector(const std::string& aK
         return itsSet->getUint64Vector(aKey, aValue, expandable);
 }
 
-//#	getFloatVector(key)
+//# getFloatVector(key)
 inline std::vector<float> ParameterSet::getFloatVector(const std::string& aKey,
                                                   bool expandable) const
 {
-	return itsSet->getFloatVector(aKey, expandable);
+  return itsSet->getFloatVector(aKey, expandable);
 }
 
-//#	getFloatVector(key, value)
+//# getFloatVector(key, value)
 inline std::vector<float> ParameterSet::getFloatVector(const std::string& aKey,
                                                   const std::vector<float>& aValue,
                                                   bool expandable) const
@@ -816,13 +816,13 @@ inline std::vector<float> ParameterSet::getFloatVector(const std::string& aKey,
         return itsSet->getFloatVector(aKey, aValue, expandable);
 }
 
-//#	getDoubleVector(key)
+//# getDoubleVector(key)
 inline std::vector<double> ParameterSet::getDoubleVector(const std::string& aKey,
                                                     bool expandable) const
 {
-	return itsSet->getDoubleVector(aKey, expandable);
+  return itsSet->getDoubleVector(aKey, expandable);
 }
-//#	getDoubleVector(key, value)
+//# getDoubleVector(key, value)
 inline std::vector<double> ParameterSet::getDoubleVector(const std::string& aKey,
                                                     const std::vector<double>& aValue,
                                                     bool expandable) const
@@ -830,14 +830,14 @@ inline std::vector<double> ParameterSet::getDoubleVector(const std::string& aKey
         return itsSet->getDoubleVector(aKey, aValue, expandable);
 }
 
-//#	getStringVector(key)
+//# getStringVector(key)
 inline std::vector<std::string> ParameterSet::getStringVector(const std::string& aKey,
                                                     bool expandable) const
 {
-	return itsSet->getStringVector(aKey, expandable);
+  return itsSet->getStringVector(aKey, expandable);
 }
 
-//#	getStringVector(key, value)
+//# getStringVector(key, value)
 inline std::vector<std::string> ParameterSet::getStringVector(const std::string& aKey,
                                                     const std::vector<std::string>& aValue,
                                                     bool expandable) const
@@ -845,14 +845,14 @@ inline std::vector<std::string> ParameterSet::getStringVector(const std::string&
         return itsSet->getStringVector(aKey, aValue, expandable);
 }
 
-//#	getTimeVector(key)
+//# getTimeVector(key)
 inline std::vector<time_t> ParameterSet::getTimeVector(const std::string& aKey,
                                                   bool expandable) const
 {
-	return itsSet->getTimeVector(aKey, expandable);
+  return itsSet->getTimeVector(aKey, expandable);
 }
 
-//#	getTimeVector(key, value)
+//# getTimeVector(key, value)
 inline std::vector<time_t> ParameterSet::getTimeVector(const std::string& aKey,
                                                   const std::vector<time_t>& aValue,
                                                   bool expandable) const

--- a/Common/ParameterValue.cc
+++ b/Common/ParameterValue.cc
@@ -27,7 +27,7 @@
 #include <stdexcept>
 
 typedef std::runtime_error ParException;
-	
+  
 
 namespace DP3 { 
 
@@ -73,13 +73,13 @@ namespace DP3 {
           nrpar--;
         } else if (itsValue[i] == '[') {
           if (nrpar != 0)
-						throw ParException("Unbalanced () around '" + itsValue + '\'');
+            throw ParException("Unbalanced () around '" + itsValue + '\'');
           nrbracket++;
         } else if (itsValue[i] == ']') {
           nrbracket--;
         } else if (itsValue[i] == '{') {
           if(nrpar != 0)
-						throw ParException("Unbalanced () around '" + itsValue + '\'');
+            throw ParException("Unbalanced () around '" + itsValue + '\'');
           nrbrace++;
         } else if (itsValue[i] == '}') {
           nrbrace--;
@@ -90,14 +90,14 @@ namespace DP3 {
           }
         }
         if (nrpar < 0 || nrbracket < 0 || nrbrace < 0)
-					throw ParException(
+          throw ParException(
                    "Unbalanced () [] or {} in '" + itsValue + '\'');
         i++;
       }
     }
     result.push_back (ParameterValue(substr(st, last)));
     if (nrpar != 0  ||  nrbracket != 0 || nrbrace != 0)
-			throw ParException("Unbalanced () [] or {} in '" + itsValue + '\'');
+      throw ParException("Unbalanced () [] or {} in '" + itsValue + '\'');
     return result;
   }
 
@@ -115,7 +115,7 @@ namespace DP3 {
     }
     if (itsValue.size() < 2 || itsValue[0] != '[' ||
                itsValue[last] != ']')
-			throw ParException("Invalid vector specification in value '"
+      throw ParException("Invalid vector specification in value '"
                + itsValue + '\'');
     return splitValue (st, last);
   }
@@ -126,7 +126,7 @@ namespace DP3 {
     uint last = itsValue.size() - 1;
     if (itsValue.size() < 2 || itsValue[0] != '{' ||
                itsValue[last] != '}')
-			throw ParException("Invalid record specification in value '"
+      throw ParException("Invalid record specification in value '"
                + itsValue + '\'');
     std::vector<ParameterValue> values (splitValue (st, last));
     // Loop over all values and split in names and values.
@@ -140,7 +140,7 @@ namespace DP3 {
       }
       std::string::size_type pos = str.find(':', st);
       if (pos == std::string::npos)
-				throw ParException("Invalid record specification in value '"
+        throw ParException("Invalid record specification in value '"
                  + str + '\'');
       // Get name and value.
       // ParameterValue is used to remove possible whitespace.

--- a/DPPP/OneApplyCal.cc
+++ b/DPPP/OneApplyCal.cc
@@ -108,7 +108,7 @@ namespace DP3 {
                          parset.getString(defaultPrefix + "correction"));
         if(itsSolTabName == "fulljones")
         {
-          std::vector<string> solTabs = parset.getStringVector("soltab", std::vector<string>{"amplitude000", "phase000"});
+          std::vector<string> solTabs = parset.getStringVector(prefix + "soltab", std::vector<string>{"amplitude000", "phase000"});
           if(solTabs.size() != 2)
             throw std::runtime_error("The soltab parameter requires two soltabs for fulljones correction (amplitude and phase)");
           itsSolTab = itsH5Parm.getSolTab(solTabs[0]);

--- a/DPPP/OneApplyCal.cc
+++ b/DPPP/OneApplyCal.cc
@@ -108,12 +108,8 @@ namespace DP3 {
                          parset.getString(defaultPrefix + "correction"));
         if(itsSolTabName == "fulljones")
         {
-          std::vector<string> solTabs = parset.getStringVector("soltab");
-          if(solTabs.empty())
-          {
-            solTabs = std::vector<string>{"amplitude000", "phase000"};
-          }
-          else if(solTabs.size() != 2)
+          std::vector<string> solTabs = parset.getStringVector("soltab", std::vector<string>{"amplitude000", "phase000"});
+          if(solTabs.size() != 2)
             throw std::runtime_error("The soltab parameter requires two soltabs for fulljones correction (amplitude and phase)");
           itsSolTab = itsH5Parm.getSolTab(solTabs[0]);
           itsSolTab2 = itsH5Parm.getSolTab(solTabs[1]);

--- a/DPPP/OneApplyCal.cc
+++ b/DPPP/OneApplyCal.cc
@@ -108,9 +108,16 @@ namespace DP3 {
                          parset.getString(defaultPrefix + "correction"));
         if(itsSolTabName == "fulljones")
         {
-          itsSolTab = itsH5Parm.getSolTab("amplitude000");
-          itsSolTab2 = itsH5Parm.getSolTab("phase000");
-          itsSolTabName = "amplitude000, phase000"; // this is only so that show() shows these tables
+          std::vector<string> solTabs = parset.getStringVector("soltab");
+          if(solTabs.empty())
+          {
+            solTabs = std::vector<string>{"amplitude000", "phase000"};
+          }
+          else if(solTabs.size() != 2)
+            throw std::runtime_error("The soltab parameter requires two soltabs for fulljones correction (amplitude and phase)");
+          itsSolTab = itsH5Parm.getSolTab(solTabs[0]);
+          itsSolTab2 = itsH5Parm.getSolTab(solTabs[1]);
+          itsSolTabName = solTabs[0] + ", " + solTabs[1]; // this is only so that show() shows these tables
           itsCorrectType = FULLJONES;
         }
         else {


### PR DESCRIPTION
This adds a parameter `applycal.soltab`, which is currently only used when `applycal.correction=fulljones`. This is a step towards implementing #16. I've tested it.