### PR TITLE
Remove malformed assignment operator without implementation

### DIFF
--- a/DPPP/H5Parm.h
+++ b/DPPP/H5Parm.h
@@ -57,8 +57,6 @@ namespace DP3 {
           // The destructor could check for valid subtables
           virtual ~SolTab();
 
-          SolTab operator=(H5::Group group);
-
           std::vector<AxisInfo>& getAxes() {return _axes;}
 
           AxisInfo getAxis(uint i) const;


### PR DESCRIPTION
I assume this is put here by accident at some point (and an assignment operator should also take it parameter by const ref).