### PR TITLE
Build DDECal without armadillo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,19 +167,24 @@ set(EXTRA_LIBRARIES ${EXTRA_LIBRARIES}
 #
 find_package(Armadillo)
 if(${ARMADILLO_FOUND})
-  include_directories(${ARMADILLO_INCLUDE_DIRS})
-  set(EXTRA_LIBRARIES ${EXTRA_LIBRARIES} ${ARMADILLO_LIBRARIES})
-  add_library(DDECal_OBJ OBJECT
-    DDECal/DDECal.cc DDECal/Register.cc DDECal/Stopwatch.cc
-    DDECal/KLFitter.cc DDECal/MultiDirSolver.cc
-    DDECal/Constraint.cc DDECal/PiercePoint.cc
-    DDECal/ScreenConstraint.cc DDECal/SmoothnessConstraint.cc
-    DDECal/TECConstraint.cc DDECal/RotationConstraint.cc
-    DDECal/RotationAndDiagonalConstraint.cc)
-  set(DDECAL_OBJECT $<TARGET_OBJECTS:DDECal_OBJ>)
+  add_definitions(-DHAVE_ARMADILLO)
+  set(DDE_ARMADILLO_FILES DDECal/KLFitter.cc DDECal/ScreenConstraint.cc)
 else()
-  message(WARNING "Armadillo was not found, not including DDECal")
+  message(WARNING "Armadillo was not found, not including screenfitter inside DDECal")
+  set(DDE_ARMADILLO_FILES)
 endif()
+
+include_directories(${ARMADILLO_INCLUDE_DIRS})
+set(EXTRA_LIBRARIES ${EXTRA_LIBRARIES} ${ARMADILLO_LIBRARIES})
+add_library(DDECal_OBJ OBJECT
+  DDECal/DDECal.cc DDECal/Register.cc DDECal/Stopwatch.cc
+  DDECal/MultiDirSolver.cc
+  DDECal/Constraint.cc DDECal/PiercePoint.cc
+  DDECal/SmoothnessConstraint.cc
+  DDECal/TECConstraint.cc DDECal/RotationConstraint.cc
+  DDECal/RotationAndDiagonalConstraint.cc
+  ${DDE_ARMADILLO_FILES})
+set(DDECAL_OBJECT $<TARGET_OBJECTS:DDECal_OBJ>)
 
 set(DPPP_GLOBAL_SOVERSION 2)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,7 +168,10 @@ set(EXTRA_LIBRARIES ${EXTRA_LIBRARIES}
 find_package(Armadillo)
 if(${ARMADILLO_FOUND})
   add_definitions(-DHAVE_ARMADILLO)
-  set(DDE_ARMADILLO_FILES DDECal/KLFitter.cc DDECal/ScreenConstraint.cc)
+  set(DDE_ARMADILLO_FILES
+    DDECal/KLFitter.cc 
+    DDECal/PiercePoint.cc 
+    DDECal/ScreenConstraint.cc)
 else()
   message(WARNING "Armadillo was not found, not including screenfitter inside DDECal")
   set(DDE_ARMADILLO_FILES)
@@ -179,7 +182,7 @@ set(EXTRA_LIBRARIES ${EXTRA_LIBRARIES} ${ARMADILLO_LIBRARIES})
 add_library(DDECal_OBJ OBJECT
   DDECal/DDECal.cc DDECal/Register.cc DDECal/Stopwatch.cc
   DDECal/MultiDirSolver.cc
-  DDECal/Constraint.cc DDECal/PiercePoint.cc
+  DDECal/Constraint.cc
   DDECal/SmoothnessConstraint.cc
   DDECal/TECConstraint.cc DDECal/RotationConstraint.cc
   DDECal/RotationAndDiagonalConstraint.cc

--- a/DDECal/DDECal.cc
+++ b/DDECal/DDECal.cc
@@ -32,11 +32,14 @@
 #include "../DPPP/Version.h"
 
 #include "Matrix2x2.h"
-#include "ScreenConstraint.h"
 #include "TECConstraint.h"
 #include "RotationConstraint.h"
 #include "RotationAndDiagonalConstraint.h"
 #include "SmoothnessConstraint.h"
+
+#ifdef HAVE_ARMADILLO
+#include "ScreenConstraint.h"
+#endif
 
 #include "../ParmDB/ParmDB.h"
 #include "../ParmDB/ParmValue.h"
@@ -243,10 +246,14 @@ namespace DP3 {
           itsFullMatrixMinimalization = false;
           break;
         case GainCal::TECSCREEN:
+#ifdef HAVE_ARMADILLO
           itsConstraints.push_back(std::unique_ptr<Constraint>(
                     new ScreenConstraint(parset, prefix+"tecscreen.")));
           itsMultiDirSolver.set_phase_only(true);
           itsFullMatrixMinimalization = false;
+#else
+          throw std::runtime_error("Can not use TEC screen: Armadillo is not available. Recompile DP3 with Armadillo.");
+#endif
           break;
         case GainCal::ROTATIONANDDIAGONAL:
           itsConstraints.push_back(std::unique_ptr<Constraint>(
@@ -421,6 +428,7 @@ namespace DP3 {
           coreConstraint->initialize(coreAntennaIndices);
         }
         
+#ifdef HAVE_ARMADILLO
         ScreenConstraint* screenConstraint = dynamic_cast<ScreenConstraint*>(itsConstraints[i].get());
         if(screenConstraint != 0)
         {
@@ -450,6 +458,7 @@ namespace DP3 {
           screenConstraint->setCoreAntennas(coreAntennaIndices);
           screenConstraint->setOtherAntennas(otherAntennaIndices);
         }
+#endif
         
         TECConstraintBase* tecConstraint = dynamic_cast<TECConstraintBase*>(itsConstraints[i].get());
         if(tecConstraint != nullptr)

--- a/DDECal/DDECal.h
+++ b/DDECal/DDECal.h
@@ -180,7 +180,6 @@ namespace DP3 {
       double           itsCoreConstraint;
       double           itsSmoothnessConstraint;
       double           itsScreenCoreConstraint;
-
       MultiDirSolver   itsMultiDirSolver;
       bool itsFullMatrixMinimalization;
       bool itsApproximateTEC;

--- a/DDECal/PiercePoint.cc
+++ b/DDECal/PiercePoint.cc
@@ -2,7 +2,7 @@
 
 using namespace arma;
 
-namespace DP3{
+namespace DP3 {
 
   const double PiercePoint::IONOheight = 300000.;
   const double PiercePoint::EarthRadius = 6371000.;

--- a/DDECal/PiercePoint.h
+++ b/DDECal/PiercePoint.h
@@ -1,7 +1,6 @@
 #ifndef PIERCEPOINT_H
 #define PIERCEPOINT_H
 
-#include <vector>
 #include <casacore/measures/Measures/MDirection.h>
 #include <casacore/measures/Measures/MCDirection.h>
 #include <casacore/measures/Measures/MCPosition.h>
@@ -11,22 +10,30 @@
 
 #include <armadillo>
 
-using namespace arma;
-namespace DP3{
+#include <vector>
+
+namespace DP3 {
  
 class PiercePoint 
 {
-  static const double IONOheight; //= 300000.; //default height in meter
-  static const double EarthRadius;// = 6371000.; //default Earth radius in meter
+  //default height in meter (300000)
+  static const double IONOheight;
+  
+  //default Earth radius in meter (6371000)
+  static const double EarthRadius;
+  
 public:
   PiercePoint(double height=PiercePoint::IONOheight);
   PiercePoint(const casacore::MPosition &ant,const casacore::MDirection &source,const double height);
   PiercePoint(const casacore::MPosition &ant,const casacore::MDirection &source);
+  
   void init(const casacore::MPosition &ant,const casacore::MDirection &source,const double height);
+  
   void evaluate(casacore::MEpoch time);
-  Col<double>  getValue() const {return itsValue;} 
+  arma::Col<double>  getValue() const {return itsValue;} 
   casacore::MPosition  getPos() const {return itsPosition;}
   casacore::MDirection  getDir() const {return itsDirection;}
+  
 private:
   //station position
   casacore::MPosition     itsPosition;
@@ -36,7 +43,9 @@ private:
   double              itsIonoHeight;
   //  square of length antenna vector (int ITRF) minus square of vector to piercepoint. This is constant for a assumed spherical Earth
   double              itsC;
-  Col<double>         itsValue; //PiercePoint in ITRF coordinates
+  arma::Col<double>         itsValue; //PiercePoint in ITRF coordinates
 };
+
 }
+
 #endif

--- a/DDECal/ScreenConstraint.cc
+++ b/DDECal/ScreenConstraint.cc
@@ -4,6 +4,8 @@
 
 #include <boost/algorithm/string/case_conv.hpp>
 
+#include <iostream>
+
 namespace DP3{
 
 const  double ScreenConstraint::phtoTEC = 1./8.4479745e9;
@@ -16,7 +18,7 @@ ScreenConstraint::ScreenConstraint(const ParameterSet& parset,
   itsCurrentTime(0),
   itsIter(0)
 {
-  cout<<"=========="<<(prefix + "order")<<"========\n";
+  std::cout<<"=========="<<(prefix + "order")<<"========\n";
   itsBeta=parset.getDouble (prefix + "beta", 5./3.);
   itsHeight=parset.getDouble (prefix + "height", 400e3);
   itsOrder=parset.getInt(prefix + "order", 3);


### PR DESCRIPTION
Fixes #57 , by conditionally compiling the screen cpp files depending on whether Armadillo is available. DDECal now compiles without Armadillo. Also removes `using namespace arma` from one of the screen header files.