### PR TITLE
Fix for #65: large number of solution flagged.

### DIFF
--- a/DDECal/DDECal.cc
+++ b/DDECal/DDECal.cc
@@ -131,15 +131,15 @@ namespace DP3 {
           string sourceDBName = parset.getString(prefix+"sourcedb");
           BBS::SourceDB sourceDB(BBS::ParmDBMeta("", sourceDBName), false);
           vector<string> patchNames = makePatchList(sourceDB, vector<string>());
-          itsDirections.resize(patchNames.size());
+          itsDirections.reserve(patchNames.size());
           for (uint i=0; i<patchNames.size(); ++i) {
-            itsDirections[i] = vector<string>(1, patchNames[i]);
+            itsDirections.emplace_back(1, patchNames[i]);
           }
         } else {
-          itsDirections.resize(strDirections.size());
+          itsDirections.reserve(strDirections.size());
           for (uint i=0; i<strDirections.size(); ++i) {
             ParameterValue dirStr(strDirections[i]);
-            itsDirections[i] = dirStr.getStringVector();
+            itsDirections.emplace_back(dirStr.getStringVector());
           }
         }
       }
@@ -274,14 +274,12 @@ namespace DP3 {
     void DDECal::initializePredictSteps(const ParameterSet& parset, const string& prefix)
     {
       const size_t nDir = itsDirections.size();
-      if (itsUseModelColumn) {
-        assert(nDir == 1);
-      } else {
-        itsPredictSteps.resize(nDir);
-        for (size_t dir=0; dir<nDir; ++dir) {
-          itsPredictSteps[dir] = Predict(itsInput, parset, prefix, itsDirections[dir]);
-          itsPredictSteps[dir].setNThreads(NThreads());
-        }
+      if(nDir == 0)
+        throw std::runtime_error("DDECal initialized with 0 directions: something is wrong with your parset or your sourcedb");
+      itsPredictSteps.resize(nDir);
+      for (size_t dir=0; dir<nDir; ++dir) {
+        itsPredictSteps[dir] = Predict(itsInput, parset, prefix, itsDirections[dir]);
+        itsPredictSteps[dir].setNThreads(NThreads());
       }
     }
 
@@ -592,8 +590,8 @@ namespace DP3 {
 
     void DDECal::doSolve ()
     {
-      for (uint constraint_num = 0; constraint_num < itsConstraints.size(); ++constraint_num) {
-        itsConstraints[constraint_num]->SetWeights(itsWeights);
+      for (std::unique_ptr<Constraint>& constraint : itsConstraints) {
+        constraint->SetWeights(itsWeights);
       }
       
       if(itsFullMatrixMinimalization)

--- a/DDECal/MultiDirBuffer.h
+++ b/DDECal/MultiDirBuffer.h
@@ -40,14 +40,30 @@ public:
       {
         for(size_t ch=0; ch!=_nChannels; ++ch)
         {
+          bool isFlagged = false;
           for (size_t cr=0; cr<4; ++cr)
           {
             const size_t index = (bl*_nChannels+ch)*4+cr;
-            // Premultiply non-flagged data with sqrt(weight)
-            float wSqrt = sqrt(weights[timestep][index]);
-            _data[timestep][index] = dataNoW[timestep][index] * wSqrt;
-            for (size_t dir=0; dir<_nDirections; ++dir) {
-              _modelData[timestep][dir][index] = modelDataNoW[timestep][dir][index] * wSqrt;
+            
+            float wSqrt;
+            if(!std::isfinite(dataNoW[timestep][index].real()) || !std::isfinite(dataNoW[timestep][index].imag()))
+              isFlagged = true;
+            else {
+              wSqrt = sqrt(weights[timestep][index]);
+              _data[timestep][index] = dataNoW[timestep][index] * wSqrt;
+              for (size_t dir=0; dir<_nDirections; ++dir) {
+                _modelData[timestep][dir][index] = modelDataNoW[timestep][dir][index] * wSqrt;
+              }
+            }
+          }
+          
+          if(isFlagged) {
+            for (size_t cr=0; cr<4; ++cr)
+            {
+              const size_t index = (bl*_nChannels+ch)*4+cr;
+              _data[timestep][index] = 0.0;
+              for (size_t dir=0; dir<_nDirections; ++dir)
+                _modelData[timestep][dir][index] = 0.0;
             }
           }
         }

--- a/DDECal/MultiDirSolver.cc
+++ b/DDECal/MultiDirSolver.cc
@@ -340,7 +340,9 @@ void MultiDirSolver::performScalarIteration(size_t channelBlockIndex,
         Matrix& gTimesC2 = gTimesCs[antenna2];
         Matrix& v2 = vs[antenna2];
         for(size_t d=0; d!=_nDirections; ++d)
+        {
           modelPtrs[d] = &modelData[timeIndex][d][(channelIndexStart + baseline * _nChannels) * 4];
+        }
         const Complex* dataPtr = &data[timeIndex][(channelIndexStart + baseline * _nChannels) * 4];
         const size_t p1top2[4] = {0, 2, 1, 3};
         for(size_t ch=channelIndexStart; ch!=channelIndexEnd; ++ch)


### PR DESCRIPTION
Caused by NaNs in the data that were no longer set to 0. Setting to zero was unintentionally skipped when #49 was implemented, particularly in commit 8ee62bf3de255acbb59b70108588cbbb7deea97d .

While testing I noticed a non-existing sourcedb causes very weird behaviour, so I added a check for this as well.