### PR TITLE
Fix for #69: problems caused by uninitialized pointer to mutex

### DIFF
--- a/DDECal/DDECal.cc
+++ b/DDECal/DDECal.cc
@@ -277,9 +277,9 @@ namespace DP3 {
       if (itsUseModelColumn) {
         assert(nDir == 1);
       } else {
-        itsPredictSteps.resize(nDir);
+        itsPredictSteps.reserve(nDir);
         for (size_t dir=0; dir<nDir; ++dir) {
-          itsPredictSteps[dir] = Predict(itsInput, parset, prefix, itsDirections[dir]);
+          itsPredictSteps.emplace_back(itsInput, parset, prefix, itsDirections[dir]);
           itsPredictSteps[dir].setNThreads(NThreads());
         }
       }

--- a/DPPP/GainCal.cc
+++ b/DPPP/GainCal.cc
@@ -113,9 +113,9 @@ namespace DP3 {
       itsUVWFlagStep.setNextStep(itsDataResultStep);
 
       if (!itsUseModelColumn) {
-        itsPredictStep=Predict(input, parset, prefix);
+        itsPredictStep.reset(new Predict(input, parset, prefix));
         itsResultStep = ResultStep::ShPtr(new ResultStep());
-        itsPredictStep.setNextStep(itsResultStep);
+        itsPredictStep->setNextStep(itsResultStep);
       } else {
 #ifdef HAVE_LOFAR_BEAM
         itsApplyBeamToModelColumn=parset.getBool(prefix +
@@ -212,7 +212,7 @@ namespace DP3 {
         }
 #endif
       } else {
-        itsPredictStep.updateInfo(infoIn);
+        itsPredictStep->updateInfo(infoIn);
       }
       if (itsApplySolution) {
         info().setWriteData();
@@ -343,7 +343,7 @@ namespace DP3 {
       os << "  use model column:    " << boolalpha << itsUseModelColumn << endl;
       itsBaselineSelection.show (os);
       if (!itsUseModelColumn) {
-        itsPredictStep.show(os);
+        itsPredictStep->show(os);
       }
 #ifdef HAVE_LOFAR_BEAM
       else if (itsApplyBeamToModelColumn) {
@@ -437,7 +437,7 @@ namespace DP3 {
         }
 #endif
       } else { // Predict
-        itsPredictStep.process(itsBuf[bufIndex]);
+        itsPredictStep->process(itsBuf[bufIndex]);
       }
 
       itsTimerPredict.stop();

--- a/DPPP/GainCal.h
+++ b/DPPP/GainCal.h
@@ -177,7 +177,7 @@ namespace DP3 {
       UVWFlagger        itsUVWFlagStep;
       ResultStep::ShPtr itsDataResultStep; // Result step for data after UV-flagging
 
-      Predict           itsPredictStep;
+      std::unique_ptr<Predict> itsPredictStep;
 #ifdef HAVE_LOFAR_BEAM
       ApplyBeam         itsApplyBeamStep; // Beam step for applying beam to modelcol
 #endif

--- a/DPPP/Predict.cc
+++ b/DPPP/Predict.cc
@@ -71,7 +71,8 @@ namespace DP3 {
     Predict::Predict (DPInput* input,
                       const ParameterSet& parset,
                       const string& prefix) :
-      itsThreadPool(nullptr)
+      itsThreadPool(nullptr),
+      itsMeasuresMutex(nullptr)
     {
       init(input, parset, prefix, parset.getStringVector(prefix + "sources",
                                                          vector<string>()));
@@ -81,7 +82,8 @@ namespace DP3 {
                       const ParameterSet& parset,
                       const string& prefix,
                       const vector<string>& sourcePatterns) :
-      itsThreadPool(nullptr)
+      itsThreadPool(nullptr),
+      itsMeasuresMutex(nullptr)
     {
       init(input, parset, prefix, sourcePatterns);
     }
@@ -169,9 +171,6 @@ namespace DP3 {
       itsResultStep=new ResultStep();
       itsApplyCalStep.setNextStep(DPStep::ShPtr(itsResultStep));
     }
-
-    Predict::Predict()
-    {}
 
     Predict::~Predict()
     {}

--- a/DPPP/Predict.h
+++ b/DPPP/Predict.h
@@ -90,8 +90,6 @@ namespace DP3 {
         itsMeasuresMutex = &measuresMutex;
       }
 
-      Predict();
-
       virtual ~Predict();
 
       // Process the data.


### PR DESCRIPTION
As reported by David, this can result in weird behaviour including a segfault.

I've also removed the default empty constructor of Predict(), as it was used to create an empty Predict class that would later be assigned too. However, this is a bit awkward with such a complex class -- better to make it nullable by putting it inside a `unique_ptr`.