### PR TITLE
Fix two nthread related crashes reported by David

### DIFF
--- a/AOFlaggerStep/AOFlaggerStep.cc
+++ b/AOFlaggerStep/AOFlaggerStep.cc
@@ -81,18 +81,18 @@ namespace DP3 {
 
     void AOFlaggerStep::show (std::ostream& os) const
     {
-      os << "AOFlaggerStep " << itsName << std::endl;
-      os << "  strategy:       " << itsStrategyName << std::endl;
-      os << "  timewindow:     " << itsWindowSize << std::endl;
-      os << "  overlap:        " << itsOverlap << std::endl;
-      os << "  pulsar:         " << itsPulsarMode << std::endl;
-      os << "  pedantic:       " << itsPedantic << std::endl;
-      os << "  keepstatistics: " << itsDoRfiStats << std::endl;
-      os << "  autocorr:       " << itsDoAutoCorr << std::endl;
-      os << "  nthreads (omp)  " << NThreads() << std::endl;
+      os << "AOFlaggerStep " << itsName << '\n';
+      os << "  strategy:       " << itsStrategyName << '\n';
+      os << "  timewindow:     " << itsWindowSize << '\n';
+      os << "  overlap:        " << itsOverlap << '\n';
+      os << "  pulsar:         " << itsPulsarMode << '\n';
+      os << "  pedantic:       " << itsPedantic << '\n';
+      os << "  keepstatistics: " << itsDoRfiStats << '\n';
+      os << "  autocorr:       " << itsDoAutoCorr << '\n';
+      os << "  nthreads (omp)  " << getInfo().nThreads() << '\n';
       os << "  max memory used ";
       formatBytes(os, itsMemoryNeeded);
-      os << std::endl;
+      os << '\n';
     }
 
     void AOFlaggerStep::formatBytes(std::ostream& os, double bytes) {
@@ -137,7 +137,7 @@ namespace DP3 {
       // Determine how much buffer space is needed per time slot.
       // The flagger needs 3 extra work buffers (data+flags) per thread.
       double timeSize = (sizeof(casacore::Complex) + sizeof(bool)) *
-        (infoIn.nbaselines() + 3*NThreads()) * infoIn.nchan() * infoIn.ncorr();
+        (infoIn.nbaselines() + 3*getInfo().nThreads()) * infoIn.nchan() * infoIn.ncorr();
       // If no overlap percentage is given, set it to 1%.
       if (itsOverlapPerc < 0  &&  itsOverlap == 0) {
         itsOverlapPerc = 1;
@@ -292,10 +292,10 @@ namespace DP3 {
         // wrapped for compatibility with older aoflaggers.
         std::unique_ptr<aoflagger::QualityStatistics> rfiStats;
       };
-      std::vector<ThreadData> threadData(NThreads());
+      std::vector<ThreadData> threadData(getInfo().nThreads());
       
       // Create thread-private counter object.
-      for(size_t t=0; t!=NThreads(); ++t)
+      for(size_t t=0; t!=getInfo().nThreads(); ++t)
       {
         threadData[t].counter.init (getInfo());
         // Create a statistics object for all polarizations.
@@ -311,7 +311,7 @@ namespace DP3 {
                                              4, false)));
       }
       
-      ParallelFor<int> loop(NThreads());
+      ParallelFor<int> loop(getInfo().nThreads());
       loop.Run(0, nrbl, [&](size_t ib, size_t thread)
       {
         // Do autocorrelations only if told so.
@@ -327,7 +327,7 @@ namespace DP3 {
       }); // end of parallel for
         
       // Add the counters to the overall object.
-      for(size_t t=0; t!=NThreads(); ++t)
+      for(size_t t=0; t!=getInfo().nThreads(); ++t)
       {
         itsFlagCounter.add (threadData[t].counter);
         if (itsDoRfiStats)

--- a/Common/ThreadPool.h
+++ b/Common/ThreadPool.h
@@ -40,7 +40,8 @@ public:
 		_priority(0)
 	{
 		size_t nThreads = NCPUS();
-		
+		if(nThreads == 0)
+			nThreads = 1;
 		// We reserve one thread less, because we always want a new For loop
 		// to be able to add a new thread (with index 0).
 		_threads.reserve(nThreads-1);
@@ -52,6 +53,8 @@ public:
 		_isStopped(false),
 		_priority(0)
 	{
+		if(nThreads == 0)
+			throw std::runtime_error("A threadPool was created with nThreads=0");
 		// We reserve one thread less, because we always want a new For loop
 		// to be able to add a new thread (with index 0).
 		_threads.reserve(nThreads-1);

--- a/DDECal/DDECal.cc
+++ b/DDECal/DDECal.cc
@@ -279,7 +279,6 @@ namespace DP3 {
       itsPredictSteps.reserve(nDir);
       for (size_t dir=0; dir<nDir; ++dir) {
         itsPredictSteps.emplace_back(itsInput, parset, prefix, itsDirections[dir]);
-        itsPredictSteps[dir].setNThreads(NThreads());
       }
     }
 
@@ -292,13 +291,11 @@ namespace DP3 {
 
       const size_t nDir = itsDirections.size();
 
-      itsUVWFlagStep.setNThreads(NThreads());
       itsUVWFlagStep.updateInfo(infoIn);
       for (size_t dir=0; dir<itsPredictSteps.size(); ++dir) {
-        itsPredictSteps[dir].setNThreads(NThreads());
         itsPredictSteps[dir].updateInfo(infoIn);
       }
-      itsMultiDirSolver.set_nthreads(NThreads());
+      itsMultiDirSolver.set_nthreads(getInfo().nThreads());
 
       if (itsSolInt==0) {
         itsSolInt=info().ntime();
@@ -311,7 +308,7 @@ namespace DP3 {
         itsModelDataPtrs[t].resize(nDir);
       }
       for (std::unique_ptr<Constraint>& constraint : itsConstraints) {
-        constraint->SetNThreads(NThreads());
+        constraint->SetNThreads(getInfo().nThreads());
         itsMultiDirSolver.add_constraint(constraint.get());
       }
 
@@ -672,7 +669,7 @@ namespace DP3 {
         itsModelDataPtrs[itsStepInSolInt][0] = itsModelData[itsStepInSolInt].data();
       } else {
         if(itsThreadPool == nullptr)
-          itsThreadPool.reset(new ThreadPool(NThreads()));
+          itsThreadPool.reset(new ThreadPool(getInfo().nThreads()));
         std::mutex measuresMutex;
         for(DP3::DPPP::Predict& predict : itsPredictSteps)
           predict.setThreadData(*itsThreadPool, measuresMutex);

--- a/DPPP/ApplyBeam.cc
+++ b/DPPP/ApplyBeam.cc
@@ -108,15 +108,16 @@ namespace DP3 {
       const size_t nSt = info().nantenna();
       const size_t nCh = info().nchan();
 
-      itsBeamValues.resize(NThreads());
+      const size_t nThreads = getInfo().nThreads();
+      itsBeamValues.resize(nThreads);
 
       // Create the Measure ITRF conversion info given the array position.
       // The time and direction are filled in later.
-      itsMeasConverters.resize(NThreads());
-      itsMeasFrames.resize(NThreads());
-      itsAntBeamInfo.resize(NThreads());
+      itsMeasConverters.resize(nThreads);
+      itsMeasFrames.resize(nThreads);
+      itsAntBeamInfo.resize(nThreads);
 
-      for (size_t thread = 0; thread < NThreads(); ++thread) {
+      for (size_t thread = 0; thread < nThreads; ++thread) {
         itsBeamValues[thread].resize(nSt * nCh);
         itsMeasFrames[thread].set(info().arrayPosCopy());
         itsMeasFrames[thread].set(
@@ -176,7 +177,7 @@ namespace DP3 {
        * itsMeasFrames seems not to be actually used.
        * André, 2018-10-07
        */
-      for (size_t threadIter = 0; threadIter < NThreads(); ++threadIter) {
+      for (size_t threadIter = 0; threadIter < getInfo().nThreads(); ++threadIter) {
         itsMeasFrames[threadIter].resetEpoch(
             MEpoch(MVEpoch(time / 86400), MEpoch::UTC));
         //Do a conversion on all threads, because converters are not

--- a/DPPP/Averager.cc
+++ b/DPPP/Averager.cc
@@ -282,7 +282,7 @@ namespace DP3 {
       uint nchan = shp[1];
       uint  nbl   = shp[2];
       uint npout = ncorr * nchan;
-      ParallelFor<uint> loop(NThreads());
+      ParallelFor<uint> loop(getInfo().nThreads());
       loop.Run(0, nbl, [&](uint k, size_t /*thread*/) {
         const Complex* indata = itsBuf.getData().data() + k*npin;
         const Complex* inalld = itsAvgAll.data() + k*npin;

--- a/DPPP/DPInfo.cc
+++ b/DPPP/DPInfo.cc
@@ -53,7 +53,8 @@ namespace DP3 {
         itsTimeAvg      (1),
         itsStartTime    (0),
         itsTimeInterval (0),
-        itsPhaseCenterIsOriginal (true)
+        itsPhaseCenterIsOriginal (true),
+        itsNThreads     (0)
     {}
 
     void DPInfo::init (uint ncorr, uint startChan, uint nchan,

--- a/DPPP/DPInfo.h
+++ b/DPPP/DPInfo.h
@@ -244,6 +244,12 @@ namespace DP3 {
 
       // Get the lengths of the baselines (in meters).
       const vector<double>& getBaselineLengths() const;
+      
+      void setNThreads(uint nThreads)
+      { itsNThreads = nThreads; }
+      
+      uint nThreads() const
+        { return itsNThreads; }
 
       // Convert to a Record.
       // The names of the fields in the record are the data names without 'its'.
@@ -299,6 +305,7 @@ namespace DP3 {
       casacore::Vector<casacore::Int>    itsAnt2;          //# ant2 of all baselines
       mutable vector<double>     itsBLength;       //# baseline lengths
       mutable vector<int>        itsAutoCorrIndex; //# autocorr index per ant
+      uint itsNThreads;
     };
 
   } //# end namespace

--- a/DPPP/DPRun.cc
+++ b/DPPP/DPRun.cc
@@ -143,19 +143,19 @@ namespace DP3 {
       DPStep::ShPtr step = firstStep;
       DPStep::ShPtr lastStep;
       while (step) {
-        step->setNThreads(numThreads);
         step = step->getNextStep();
       }
       
-      // Call updateInfo() (after setting NThreads())
-      firstStep->setInfo (DPInfo());
+      // Call updateInfo()
+      DPInfo dpInfo;
+      dpInfo.setNThreads(numThreads);
+      firstStep->setInfo (std::move(dpInfo));
 
       // Show the steps.  
       step = firstStep;
       while (step) {
         std::ostringstream os;
         step->show (os);
-        step->setNThreads(numThreads);
         DPLOG_INFO (os.str(), true);
         lastStep = step;
         step = step->getNextStep();

--- a/DPPP/DPStep.h
+++ b/DPPP/DPStep.h
@@ -71,7 +71,7 @@ namespace DP3 {
 
       // Constructor to initialize.
       DPStep()
-        : itsPrevStep(0), itsNThreads(0)
+        : itsPrevStep(0)
       {}
 
       // Destructor.
@@ -127,12 +127,6 @@ namespace DP3 {
       const DPStep::ShPtr& getNextStep() const
         { return itsNextStep; }
         
-      void setNThreads(size_t nThreads)
-      { itsNThreads = nThreads; }
-      
-      size_t NThreads() const
-      { return itsNThreads; }
-
     protected:
       DPInfo& info()
         { return itsInfo; }
@@ -147,7 +141,6 @@ namespace DP3 {
       DPStep* itsPrevStep; // Normal pointer for back links, prevent
                            // two shared pointers to same object
       DPInfo itsInfo;
-      size_t itsNThreads;
     };
 
 

--- a/DPPP/Demixer.cc
+++ b/DPPP/Demixer.cc
@@ -146,7 +146,7 @@ namespace DP3 {
       itsFilter.setNextStep (nullStep);
       // Default nr of time chunks is maximum number of threads.
       if (itsNTimeChunk == 0) {
-        itsNTimeChunk = NThreads();
+        itsNTimeChunk = getInfo().nThreads();
       }
       // Check that time windows fit integrally.
       if ((itsNTimeChunk * itsNTimeAvg) % itsNTimeAvgSubtr != 0)
@@ -631,7 +631,7 @@ namespace DP3 {
       // source direction. By combining them you get the shift from one
       // source direction to another.
       int dirnr = 0;
-      ParallelFor<size_t> loop(NThreads());
+      ParallelFor<size_t> loop(getInfo().nThreads());
       for (uint i1=0; i1<itsNDir-1; ++i1) {
         for (uint i0=i1+1; i0<itsNDir; ++i0) {
           if (i0 == itsNDir-1) {
@@ -710,7 +710,7 @@ namespace DP3 {
           // Note that summing in time is done in addFactors.
           // The sum per output channel is divided by the summed weight.
           // Note there is a summed weight per baseline,outchan,corr.
-          ParallelFor<size_t> loop(NThreads());
+          ParallelFor<size_t> loop(getInfo().nThreads());
           loop.Run(0, itsNBl, [&](size_t k, size_t /*thread*/)
           {
             const DComplex* phin = bufIn.data() + (dirnr*itsNBl + k)*nccin;
@@ -857,7 +857,7 @@ namespace DP3 {
 
     void Demixer::demix()
     {
-      const size_t nThread = NThreads();
+      const size_t nThread = getInfo().nThreads();
       const size_t nTime = itsAvgResults[0]->size();
       const size_t nTimeSubtr = itsAvgResultSubtr->size();
       const size_t multiplier = itsNTimeAvg / itsNTimeAvgSubtr;
@@ -887,7 +887,7 @@ namespace DP3 {
 
       const_cursor<Baseline> cr_baseline(&(itsBaselines[0]));
 
-      ParallelFor<size_t> loop(NThreads());
+      ParallelFor<size_t> loop(getInfo().nThreads());
       loop.Run(0, nTime, [&](size_t ts, size_t thread)
       {
         ThreadPrivateStorage &storage = threadStorage[thread];

--- a/DPPP/DemixerNew.cc
+++ b/DPPP/DemixerNew.cc
@@ -74,13 +74,13 @@ namespace DP3 {
       // Handle possible data selection.
       itsFilter.updateInfo (getInfo());
       // Update itsDemixInfo and info().
-      itsDemixInfo.update (itsFilter.getInfo(), info(), NThreads());
+      itsDemixInfo.update (itsFilter.getInfo(), info(), getInfo().nThreads());
       // Size the buffers.
       itsBufIn.resize (itsDemixInfo.ntimeChunk() * itsDemixInfo.chunkSize());
       itsBufOut.resize(itsDemixInfo.ntimeChunk() * itsDemixInfo.ntimeOutSubtr());
       itsSolutions.resize(itsDemixInfo.ntimeChunk() * itsDemixInfo.ntimeOut());
       // Create a worker per thread.
-      size_t nthread = NThreads();
+      size_t nthread = getInfo().nThreads();
       itsWorkers.reserve (nthread);
       for (size_t i=0; i<nthread; ++i) {
         itsWorkers.emplace_back (itsInput, itsName, itsDemixInfo,
@@ -369,7 +369,7 @@ namespace DP3 {
                       / itsDemixInfo.ntimeAvgSubtr());
       int ntimeSol = ((itsNTime + itsDemixInfo.ntimeAvg() - 1)
                       / itsDemixInfo.ntimeAvg());
-      ParallelFor<int> loop(NThreads());
+      ParallelFor<int> loop(getInfo().nThreads());
       loop.Run(0, lastChunk, [&](int i, size_t thread)
       {
         if (i == lastChunk) {

--- a/DPPP/GainCal.cc
+++ b/DPPP/GainCal.cc
@@ -213,6 +213,7 @@ namespace DP3 {
 #endif
       } else {
         itsPredictStep->updateInfo(infoIn);
+        itsPredictStep->setNThreads(NThreads());
       }
       if (itsApplySolution) {
         info().setWriteData();

--- a/DPPP/GainCal.cc
+++ b/DPPP/GainCal.cc
@@ -213,7 +213,6 @@ namespace DP3 {
 #endif
       } else {
         itsPredictStep->updateInfo(infoIn);
-        itsPredictStep->setNThreads(NThreads());
       }
       if (itsApplySolution) {
         info().setWriteData();
@@ -303,7 +302,7 @@ namespace DP3 {
       itsChunkStartTime = info().startTime();
 
       if (itsDebugLevel>0) {
-        assert(NThreads()==1);
+        assert(getInfo().nThreads()==1);
         assert(itsTimeSlotsPerParmUpdate >= info().ntime());
         itsAllSolutions.resize(IPosition(6,
                                iS[0].numCorrelations(),
@@ -637,7 +636,7 @@ namespace DP3 {
       vector<StefCal::Status> converged(itsNFreqCells,StefCal::NOTCONVERGED);
       for (;iter<itsMaxIter;++iter) {
         bool allConverged=true;
-        ParallelFor<size_t> loop(NThreads());
+        ParallelFor<size_t> loop(getInfo().nThreads());
         loop.Run(0, itsNFreqCells, [&](size_t freqCell, size_t /*thread*/) {
           // Do another step when stalled and not all converged
           if (converged[freqCell]!=StefCal::CONVERGED)
@@ -689,7 +688,7 @@ namespace DP3 {
             }
           }
 
-          ParallelFor<size_t> loop(NThreads());
+          ParallelFor<size_t> loop(getInfo().nThreads());
           loop.Run(0, nSt, [&](size_t st, size_t /*thread*/) {
             uint numpoints=0;
             double* phases = itsPhaseFitters[st]->PhaseData();

--- a/DPPP/H5ParmPredict.cc
+++ b/DPPP/H5ParmPredict.cc
@@ -111,7 +111,6 @@ namespace DP3 {
 
       for(Predict::ShPtr& predictstep : itsPredictSteps)
       {
-        predictstep->setNThreads(NThreads());
         predictstep->updateInfo(infoIn);
       }
     }
@@ -135,7 +134,7 @@ namespace DP3 {
 
     bool H5ParmPredict::process (const DPBuffer& bufin)
     {
-      itsThreadPool.SetNThreads(NThreads());
+      itsThreadPool.SetNThreads(getInfo().nThreads());
       
       itsTimer.start();
       itsBuffer.copy (bufin);

--- a/DPPP/MSReader.cc
+++ b/DPPP/MSReader.cc
@@ -211,8 +211,10 @@ namespace DP3 {
     MSReader::~MSReader()
     {}
 
-    void MSReader::updateInfo (const DPInfo&)
-    {}
+    void MSReader::updateInfo (const DPInfo& dpInfo)
+    {
+      info().setNThreads(dpInfo.nThreads());
+    }
 
     std::string MSReader::msName() const
     {

--- a/DPPP/MedFlagger.cc
+++ b/DPPP/MedFlagger.cc
@@ -293,7 +293,7 @@ namespace DP3 {
         NSTimer medianTimer;
         float Z1, Z2;
       };
-      std::vector<ThreadData> threadData(NThreads());
+      std::vector<ThreadData> threadData(getInfo().nThreads());
       
       // Create a temporary buffer (per thread) to hold data for determining
       // the medians.
@@ -306,7 +306,7 @@ namespace DP3 {
       
       // The for loop can be parallellized. This must be done dynamically,
       // because the execution time of each iteration can vary a lot.
-      ParallelFor<size_t> loop(NThreads());
+      ParallelFor<size_t> loop(getInfo().nThreads());
       loop.Run(0, nrbl, [&](size_t ib, size_t thread) {
         ThreadData& data = threadData[thread];
         const float* dataPtr = bufDataPtr + ib*blsize;

--- a/DPPP/OneApplyCal.cc
+++ b/DPPP/OneApplyCal.cc
@@ -389,7 +389,7 @@ namespace DP3 {
 
       size_t nchan = itsBuffer.getData().shape()[1];
 
-      ParallelFor<size_t> loop(NThreads());
+      ParallelFor<size_t> loop(getInfo().nThreads());
       loop.Run(0, nbl, [&](size_t bl, size_t /*thread*/) {
         for (size_t chan=0;chan<nchan;chan++) {
           uint timeFreqOffset=(itsTimeStep*info().nchan())+chan;

--- a/DPPP/PhaseShift.cc
+++ b/DPPP/PhaseShift.cc
@@ -137,7 +137,7 @@ namespace DP3 {
       //# If ever in the future a time dependent phase center is used,
       //# the machine must be reset for each new time, thus each new call
       //# to process.
-      ParallelFor<size_t> loop(NThreads());
+      ParallelFor<size_t> loop(getInfo().nThreads());
       loop.Run(0, nbl, [&](size_t bl, size_t /*thread*/) {
         Complex*  __restrict__ data    = itsBuf.getData().data() + bl*nchan*ncorr;
         double*   __restrict__ uvw     = itsBuf.getUVW().data() + bl*3;

--- a/DPPP/Predict.h
+++ b/DPPP/Predict.h
@@ -116,6 +116,7 @@ namespace DP3 {
       std::pair<double, double> getFirstDirection() const;
 
     private:
+      void initializeThreadData();
 #ifdef HAVE_LOFAR_BEAM
       LOFAR::StationResponse::vector3r_t dir2Itrf (const casacore::MDirection& dir,
                                      casacore::MDirection::Convert& measConverter);


### PR DESCRIPTION
This fixes the vector reserve exception #73 and the 2nd segfault reported in that bug report, both crashes occuring in the model predictor when using gaincal.

NThreads is now moved to the DPInfo object, as earlier suggested also by @tammojan , which avoids all the manual setting.