### PR TITLE
Use of Model_data with DDECal reported error

### DIFF
--- a/DDECal/DDECal.cc
+++ b/DDECal/DDECal.cc
@@ -276,9 +276,12 @@ namespace DP3 {
       const size_t nDir = itsDirections.size();
       if(nDir == 0)
         throw std::runtime_error("DDECal initialized with 0 directions: something is wrong with your parset or your sourcedb");
-      itsPredictSteps.reserve(nDir);
-      for (size_t dir=0; dir<nDir; ++dir) {
-        itsPredictSteps.emplace_back(itsInput, parset, prefix, itsDirections[dir]);
+      if (!itsUseModelColumn)
+      {
+        itsPredictSteps.reserve(nDir);
+        for (size_t dir=0; dir<nDir; ++dir) {
+          itsPredictSteps.emplace_back(itsInput, parset, prefix, itsDirections[dir]);
+        }
       }
     }
 


### PR DESCRIPTION
Fixes #78: 'sourcedb keyword with model_data' reported by Francesco