### PR TITLE
Interpolate applycal

### DIFF
--- a/DPPP/GridInterpolate.cc
+++ b/DPPP/GridInterpolate.cc
@@ -96,7 +96,50 @@ namespace DP3 {
         }
       }
     } else {
-      throw std::logic_error("Not implemented");
+      for (size_t i=0; i<nx; ++i) {
+        for (size_t j=0; j<ny; ++j) {
+          size_t y0_idx, y1_idx;
+          bool interpolate_y = true;
+          if (y_tgt[j]<=y_src.front()) {
+            y0_idx = 0;
+            y1_idx = 0;
+            interpolate_y = false;
+          } else if (y_tgt[j]>=y_src.back()) {
+            y0_idx = y_src.size()-1;
+            y1_idx = y_src.size()-1;
+            interpolate_y = false;
+          } else {
+            y0_idx = y_indices[j];
+            y1_idx = y_indices[j]+1;
+          }
+
+          double f_y0, f_y1;
+          if (x_tgt[i]<=x_src.front()) {
+            f_y0 = vals_src[y0_idx];
+            f_y1 = vals_src[y1_idx];
+          }
+          else if (x_tgt[i]>=x_src.back()) {
+            f_y0 = vals_src[(x_src.size()-1)*ny_src+y0_idx];
+            f_y1 = vals_src[(x_src.size()-1)*ny_src+y1_idx];
+          }
+          else {
+            size_t x0_idx = x_indices[i];
+            double x0 = x_src[x0_idx];
+            double x1 = x_src[x0_idx+1];
+            double x = x_tgt[i];
+            f_y0 = vals_src[x0_idx*ny_src+y0_idx] + (x-x0)/(x1-x0) *(vals_src[(x0_idx+1)*ny_src+y0_idx]-vals_src[x0_idx*ny_src+y0_idx]);
+            f_y1 = vals_src[x0_idx*ny_src+y1_idx] + (x-x0)/(x1-x0) *(vals_src[(x0_idx+1)*ny_src+y1_idx]-vals_src[x0_idx*ny_src+y1_idx]);
+          }
+          if (interpolate_y) {
+            double y0 = y_src[y0_idx];
+            double y1 = y_src[y0_idx+1];
+            double y = y_tgt[j];
+            vals_tgt[i*ny+j] = f_y0 + (y-y0)/(y1-y0)*(f_y1-f_y0);
+          } else {
+            vals_tgt[i*ny+j] = f_y0;
+          }
+        }
+      }
     }
   }
 }

--- a/DPPP/H5Parm.h
+++ b/DPPP/H5Parm.h
@@ -139,9 +139,9 @@ namespace DP3 {
           // Get the values of this SolTab for a given antenna.
           std::vector<double> getValues(
                                         const std::string& antName,
-                                        uint starttimeslot, uint ntime, uint timestep=1,
-                                        uint startfreq=0, uint nfreq=1, uint freqstep=1,
-                                        uint pol=0, uint dir=0) {
+                                        uint starttimeslot, uint ntime, uint timestep,
+                                        uint startfreq, uint nfreq, uint freqstep,
+                                        uint pol, uint dir) {
             return getValuesOrWeights("val", antName,
                                       starttimeslot, ntime, timestep,
                                       startfreq, nfreq, freqstep,
@@ -151,9 +151,9 @@ namespace DP3 {
           // Get the weights of this SolTab for a given antenna.
           std::vector<double> getWeights(
                                         const std::string& antName,
-                                        uint starttimeslot, uint ntime, uint timestep=1,
-                                        uint startfreq=0, uint nfreq=1, uint freqstep=1,
-                                        uint pol=0, uint dir=0) {
+                                        uint starttimeslot, uint ntime, uint timestep,
+                                        uint startfreq, uint nfreq, uint freqstep,
+                                        uint pol, uint dir) {
             return getValuesOrWeights("weight", antName,
                                       starttimeslot, ntime, timestep,
                                       startfreq, nfreq, freqstep,
@@ -165,7 +165,7 @@ namespace DP3 {
                                         const std::string& antName,
                                         const std::vector<double>& times,
                                         const std::vector<double>& freqs,
-                                        uint pol, uint dir);
+                                        uint pol, uint dir, bool nearest);
         private:
           // Get the values or weights of this SolTab for a given antenna.
           std::vector<double> getValuesOrWeights(

--- a/DPPP/OneApplyCal.cc
+++ b/DPPP/OneApplyCal.cc
@@ -96,6 +96,16 @@ namespace DP3 {
       }
 
       if (itsUseH5Parm) {
+        string interpolationStr = (parset.isDefined(prefix + "interpolation") ?
+                            parset.getString(prefix + "interpolation") :
+                            parset.getString(prefix + "interpolation", "nearest"));
+        if (interpolationStr == "nearest") {
+          itsInterpolationType = InterpolationType::NEAREST;
+        } else if (interpolationStr == "linear") {
+          itsInterpolationType = InterpolationType::LINEAR;
+        } else {
+          throw std::runtime_error("Unsupported interpolation mode: " + interpolationStr);
+        }
         itsTimeSlotsPerParmUpdate = 0;
         string directionStr;
         directionStr = (parset.isDefined(prefix + "direction") ?
@@ -341,20 +351,21 @@ namespace DP3 {
         os << "  H5Parm:         " << itsParmDBName << '\n';
         os << "    SolSet:       " << itsH5Parm.getSolSetName() << '\n';
         os << "    SolTab:       " << itsSolTabName << '\n';
-        os << " Direction:       " << itsDirection << '\n';
+        os << "  Direction:      " << itsDirection << '\n';
+        os << "  Interpolation:  " << (itsInterpolationType==InterpolationType::NEAREST?"nearest":"linear") << '\n';
       } else {
-        os << "  parmdb:         " << itsParmDBName << '\n';
+        os << "  Parmdb:         " << itsParmDBName << '\n';
       }
-      os << "  correction:     " << correctTypeToString(itsCorrectType) << '\n';
+      os << "  Correction:     " << correctTypeToString(itsCorrectType) << '\n';
       if (itsCorrectType==GAIN || itsCorrectType==FULLJONES) {
         os << "    Ampl/Phase:   " << boolalpha << itsUseAP << '\n';
       }
-      os << "  update weights: " << boolalpha << itsUpdateWeights << '\n';
-      os << "  invert:         " << boolalpha << itsInvert <<'\n';
+      os << "  Update weights: " << boolalpha << itsUpdateWeights << '\n';
+      os << "  Invert:         " << boolalpha << itsInvert <<'\n';
       if (itsInvert) {
-      os << "    sigmaMMSE:    " << itsSigmaMMSE << '\n';
+      os << "    SigmaMMSE:    " << itsSigmaMMSE << '\n';
       }
-      os << "  timeSlotsPerParmUpdate: " << itsTimeSlotsPerParmUpdate <<'\n';
+      os << "  TimeSlotsPerParmUpdate: " << itsTimeSlotsPerParmUpdate <<'\n';
     }
 
     void OneApplyCal::showTimings (std::ostream& os, double duration) const
@@ -512,16 +523,18 @@ namespace DP3 {
               parmvalues[pol*2][ant] = itsSolTab.getValuesOrWeights("val",
                 info().antennaNames()[ant],
                 times, freqs,
-                pol, itsDirection);
+                pol, itsDirection, itsInterpolationType==InterpolationType::NEAREST);
               weights = itsSolTab.getValuesOrWeights("weight",
-                info().antennaNames()[ant], times, freqs, pol, itsDirection);
+                info().antennaNames()[ant], times, freqs, pol, itsDirection,
+                itsInterpolationType==InterpolationType::NEAREST);
               applyFlags(parmvalues[pol*2][ant], weights);
               parmvalues[pol*2+1][ant] = itsSolTab2.getValuesOrWeights("val",
                 info().antennaNames()[ant],
                 times, freqs,
-                pol, itsDirection);
+                pol, itsDirection, itsInterpolationType==InterpolationType::NEAREST);
               weights = itsSolTab2.getValuesOrWeights("weight",
-                info().antennaNames()[ant], times, freqs, pol, itsDirection);
+                info().antennaNames()[ant], times, freqs, pol, itsDirection,
+                itsInterpolationType==InterpolationType::NEAREST);
               applyFlags(parmvalues[pol*2+1][ant], weights);
             }
           }
@@ -530,9 +543,10 @@ namespace DP3 {
               parmvalues[pol][ant] = itsSolTab.getValuesOrWeights("val",
                 info().antennaNames()[ant],
                 times, freqs,
-                pol, itsDirection);
+                pol, itsDirection, itsInterpolationType==InterpolationType::NEAREST);
               weights = itsSolTab.getValuesOrWeights("weight",
-                info().antennaNames()[ant], times, freqs, pol, itsDirection);
+                info().antennaNames()[ant], times, freqs, pol, itsDirection,
+                itsInterpolationType==InterpolationType::NEAREST);
               applyFlags(parmvalues[pol][ant], weights);
             }
           }

--- a/DPPP/OneApplyCal.h
+++ b/DPPP/OneApplyCal.h
@@ -54,6 +54,8 @@ namespace DP3 {
       // Define the shared pointer for this type.
       typedef std::shared_ptr<OneApplyCal> ShPtr;
 
+      enum class InterpolationType {NEAREST, LINEAR};
+
       enum CorrectType {GAIN, FULLJONES, TEC, CLOCK, ROTATIONANGLE, SCALARPHASE, PHASE,
                         ROTATIONMEASURE, SCALARAMPLITUDE, AMPLITUDE};
 
@@ -124,6 +126,7 @@ namespace DP3 {
       H5Parm::SolTab   itsSolTab2; // in the case of full Jones, amp and phase table need to be open
       CorrectType      itsCorrectType;
       bool             itsInvert;
+      InterpolationType itsInterpolationType;
       uint             itsTimeSlotsPerParmUpdate;
       double           itsSigmaMMSE;
       bool             itsUpdateWeights;

--- a/DPPP/SolTab.cc
+++ b/DPPP/SolTab.cc
@@ -216,7 +216,7 @@ namespace DP3 {
               const string& antName,
               const vector<double>& times,
               const vector<double>& freqs,
-              uint pol, uint dir) {
+              uint pol, uint dir, bool nearest) {
     vector<double> res(times.size()*freqs.size());
 
     uint startTimeSlot = 0;
@@ -250,7 +250,8 @@ namespace DP3 {
     gridNearestNeighbor(timeAxisH5, freqAxisH5,
                         times, freqs,
                         &(h5values[0]),
-                        &(interpolated[0]));
+                        &(interpolated[0]),
+                        nearest);
 
     return interpolated;
   }

--- a/DPPP/Version.h
+++ b/DPPP/Version.h
@@ -8,7 +8,7 @@ class DPPPVersion
 public:
 	static std::string AsString()
 	{
-		return "DPPP 0.0"; // TODO
+		return "DPPP 4.0";
 	}
 };
 


### PR DESCRIPTION
This adds optional bilinear interpolation for ApplyCal, on frequency and time. Default is to keep doing nearest neighbor interpolation.

Linear interpolation could be very useful if some data is omitted during calibration.

The interpolation is on the real values in the H5Parm, so on either the amplitudes (where it makes sense) or on the phases (where linear interpolation doesn't necessarily makes sense).

I'm not sure if interpolating the weights is the right thing to do.