### PR TITLE
Fix compilation with newest casacore

### DIFF
--- a/AOFlaggerStep/AOFlaggerStep.h
+++ b/AOFlaggerStep/AOFlaggerStep.h
@@ -140,7 +140,7 @@ namespace DP3 {
       bool             itsPedantic;
       bool             itsDoAutoCorr;
       bool             itsDoRfiStats;
-      vector<DPBuffer> itsBuf;
+      std::vector<DPBuffer> itsBuf;
       FlagCounter      itsFlagCounter;
       NSTimer          itsTimer;
       NSTimer          itsQualityTimer;  //# quality writing timer

--- a/Blob/BlobArray.tcc
+++ b/Blob/BlobArray.tcc
@@ -161,7 +161,7 @@ BlobOStream& operator<< (BlobOStream& bs, const casacore::Array<T>& arr)
   bool deleteIt;
   const T* data = arr.getStorage(deleteIt);
   const casacore::IPosition& shape = arr.shape();
-  vector<uint64_t> shp(shape.begin(), shape.end());
+  std::vector<uint64_t> shp(shape.begin(), shape.end());
   putBlobArray (bs, data, shp.empty() ? 0 : &shp[0], arr.ndim(), true);
   arr.freeStorage (data, deleteIt);
   return bs;
@@ -174,7 +174,7 @@ BlobIStream& operator>> (BlobIStream& bs, casacore::Array<T>& arr)
   bool fortranOrder;
   uint16_t ndim;
   uint nalign = getBlobArrayStart (bs, fortranOrder, ndim);
-  vector<uint64_t> shp(ndim);
+  std::vector<uint64_t> shp(ndim);
   getBlobArrayShape (bs, ndim==0 ? 0 : &shp[0], ndim,
                      !fortranOrder, nalign);
   casacore::IPosition shape(ndim);

--- a/Common/VdsMaker.h
+++ b/Common/VdsMaker.h
@@ -68,32 +68,32 @@ namespace DP3 {
 
     // Combine the given VDS file into a global VDS file.
     static void combine (const string& gdsName,
-                         const vector<string>& vdsNames);
+                         const std::vector<string>& vdsNames);
 
   private:
     // Get the frequency info for each spectral window in the MS.
     // The vectors get the start and end frequency of each channel.
-    static void getFreqInfo (casacore::MS& ms, vector<int>& nrchan,
-			     vector<casacore::Vector<double> >& startFreq,
-			     vector<casacore::Vector<double> >& endFreq);
+    static void getFreqInfo (casacore::MS& ms, std::vector<int>& nrchan,
+			     std::vector<casacore::Vector<double> >& startFreq,
+			     std::vector<casacore::Vector<double> >& endFreq);
 
     // Get the directions of the fields.
     static void getFields (casacore::MS& ms,
-			   vector<double>& ra, vector<double>& dec,
-                           vector<string>& refType);
+			   std::vector<double>& ra, std::vector<double>& dec,
+                           std::vector<string>& refType);
 
     // Get the names of the antennae (stations).
-    static void getAntNames (casacore::MS& ms, vector<string>& antNames);
+    static void getAntNames (casacore::MS& ms, std::vector<string>& antNames);
 
     // Get the names of the correlations (polarisations).
-    static void getCorrInfo (casacore::MS& ms, vector<string>& corrTypes);
+    static void getCorrInfo (casacore::MS& ms, std::vector<string>& corrTypes);
 
     // Find out which file contains the DATA column.
     // Determine if the DATA are stored in a TSM file of itself.
     // Determine the cube and tile shape.
     static void getDataFileInfo (casacore::MS& ms, string& name, bool& regular,
-				 vector<int>& tileShape,
-				 vector<int>& cubeShape);
+				 std::vector<int>& tileShape,
+				 std::vector<int>& cubeShape);
 
     // Find the file system on which the given file is located.
     // If the host name is empty, gethostname() will be used.

--- a/DDECal/KLFitter.cc
+++ b/DDECal/KLFitter.cc
@@ -13,7 +13,7 @@ KLFitter::KLFitter(double r0,double beta,int order):
 
 
 
-void KLFitter::calculateCorrMatrix(const vector<PiercePoint> pp){
+void KLFitter::calculateCorrMatrix(const std::vector<PiercePoint> pp){
   itsPiercePoints.set_size(pp.size(),3);
   _phases.set_size(pp.size());
   _weights=eye<mat>(pp.size(),pp.size()); //TODO, make weights sensible
@@ -35,7 +35,7 @@ void KLFitter::calculateCorrMatrix(const vector<PiercePoint> pp){
   itsinvU=inv(itsU.t()*(_weights*itsU)); 
 }
 
-void KLFitter::calculateCorrMatrix(const vector<PiercePoint*> pp){
+void KLFitter::calculateCorrMatrix(const std::vector<PiercePoint*> pp){
   itsPiercePoints.set_size(pp.size(),3);
   _phases.set_size(pp.size());
   _weights=eye<mat>(pp.size(),pp.size()); //TODO, make weights sensible

--- a/DDECal/KLFitter.h
+++ b/DDECal/KLFitter.h
@@ -12,8 +12,8 @@ class KLFitter
 {//creates KH base and fits screens from collection of PiercePoints
 public:
   KLFitter(double r0=1000.,double beta=5./3.,int order=3);
-  void calculateCorrMatrix(const vector<PiercePoint> pp);
-  void calculateCorrMatrix(const vector<PiercePoint*> pp);
+  void calculateCorrMatrix(const std::vector<PiercePoint> pp);
+  void calculateCorrMatrix(const std::vector<PiercePoint*> pp);
   void doFit();
   size_t getOrder() const {return itsOrder;}
   double* PhaseData() { return _phases.memptr(); }

--- a/DPPP/ApplyBeam.h
+++ b/DPPP/ApplyBeam.h
@@ -97,8 +97,8 @@ namespace DP3 {
             const LOFAR::StationResponse::vector3r_t& srcdir,
             const LOFAR::StationResponse::vector3r_t& refdir,
             const LOFAR::StationResponse::vector3r_t& tiledir,
-            const vector<LOFAR::StationResponse::Station::Ptr>& antBeamInfo,
-            vector<LOFAR::StationResponse::matrix22c_t>& beamValues,
+            const std::vector<LOFAR::StationResponse::Station::Ptr>& antBeamInfo,
+            std::vector<LOFAR::StationResponse::matrix22c_t>& beamValues,
             bool useChannelFreq, bool invert, int mode,
             bool doUpdateWeights=false);
 
@@ -113,7 +113,7 @@ namespace DP3 {
         DPBuffer             itsBuffer;
         bool                 itsInvert;
         bool                 itsUpdateWeights;
-        vector<string>       itsDirectionStr;
+        std::vector<string>       itsDirectionStr;
         casacore::MDirection itsDirection;
         bool                 itsUseChannelFreq;
         //Position             itsPhaseRef;
@@ -122,10 +122,10 @@ namespace DP3 {
         uint                 itsDebugLevel;
 
         // The info needed to calculate the station beams.
-        vector<vector<LOFAR::StationResponse::Station::Ptr> > itsAntBeamInfo;
-        vector<casacore::MeasFrame> itsMeasFrames;
-        vector<casacore::MDirection::Convert> itsMeasConverters;
-        vector<vector<LOFAR::StationResponse::matrix22c_t> > itsBeamValues;
+        std::vector<std::vector<LOFAR::StationResponse::Station::Ptr> > itsAntBeamInfo;
+        std::vector<casacore::MeasFrame> itsMeasFrames;
+        std::vector<casacore::MDirection::Convert> itsMeasConverters;
+        std::vector<std::vector<LOFAR::StationResponse::matrix22c_t> > itsBeamValues;
 
         NSTimer itsTimer;
     };

--- a/DPPP/BaselineSelection.h
+++ b/DPPP/BaselineSelection.h
@@ -94,7 +94,7 @@ namespace DP3 {
       //# Data members
       string itsStrBL;
       string itsCorrType;
-      vector<double> itsRangeBL;
+      std::vector<double> itsRangeBL;
     };
 
   } //# end namespace

--- a/DPPP/DPInfo.h
+++ b/DPPP/DPInfo.h
@@ -93,7 +93,7 @@ namespace DP3 {
       // Set the info for the given antennae and baselines.
       void set (const casacore::Vector<casacore::String>& antNames,
                 const casacore::Vector<casacore::Double>& antDiam,
-                const vector<casacore::MPosition>& antPos,
+                const std::vector<casacore::MPosition>& antPos,
                 const casacore::Vector<casacore::Int>& ant1,
                 const casacore::Vector<casacore::Int>& ant2);
 
@@ -116,7 +116,7 @@ namespace DP3 {
       // Update the info from the given selection parameters.
       // Optionally unused stations are really removed from the antenna lists.
       void update (uint startChan, uint nchan,
-                   const vector<uint>& baselines, bool remove);
+                   const std::vector<uint>& baselines, bool remove);
 
       // Remove unused stations from the antenna lists.
       void removeUnusedAnt();
@@ -162,7 +162,7 @@ namespace DP3 {
         { return itsAntNames; }
       const casacore::Vector<casacore::Double>& antennaDiam() const
         { return itsAntDiam; }
-      const vector<casacore::MPosition>& antennaPos() const
+      const std::vector<casacore::MPosition>& antennaPos() const
         { return itsAntPos; }
       const casacore::MPosition& arrayPos() const
         { return itsArrayPos; }
@@ -201,13 +201,13 @@ namespace DP3 {
 
       // Get the antenna numbers actually used in the (selected) baselines.
       // E.g. [0,2,5,6]
-      const vector<int>& antennaUsed() const
+      const std::vector<int>& antennaUsed() const
         { return itsAntUsed; }
 
       // Get the indices of all antennae in the used antenna vector above.
       // -1 means that the antenna is not used.
       // E.g. [0,-1,1,-1,-1,2,3] for the example above.
-      const vector<int>& antennaMap() const
+      const std::vector<int>& antennaMap() const
         { return itsAntMap; }
 
       // Are the visibility data needed?
@@ -247,10 +247,10 @@ namespace DP3 {
 
       // Get the baseline table index of the autocorrelations.
       // A negative value means there are no autocorrelations for that antenna.
-      const vector<int>& getAutoCorrIndex() const;
+      const std::vector<int>& getAutoCorrIndex() const;
 
       // Get the lengths of the baselines (in meters).
-      const vector<double>& getBaselineLengths() const;
+      const std::vector<double>& getBaselineLengths() const;
       
       void setNThreads(uint nThreads)
       { itsNThreads = nThreads; }
@@ -317,13 +317,13 @@ namespace DP3 {
       double                     itsRefFreq;
       casacore::Vector<casacore::String> itsAntNames;
       casacore::Vector<casacore::Double> itsAntDiam;
-      vector<casacore::MPosition>    itsAntPos;
-      vector<int>                itsAntUsed;
-      vector<int>                itsAntMap;
+      std::vector<casacore::MPosition>    itsAntPos;
+      std::vector<int>                itsAntUsed;
+      std::vector<int>                itsAntMap;
       casacore::Vector<casacore::Int>    itsAnt1;          //# ant1 of all baselines
       casacore::Vector<casacore::Int>    itsAnt2;          //# ant2 of all baselines
-      mutable vector<double>     itsBLength;       //# baseline lengths
-      mutable vector<int>        itsAutoCorrIndex; //# autocorr index per ant
+      mutable std::vector<double>     itsBLength;       //# baseline lengths
+      mutable std::vector<int>        itsAutoCorrIndex; //# autocorr index per ant
       uint itsNThreads;
     };
 

--- a/DPPP/DPInput.h
+++ b/DPPP/DPInput.h
@@ -103,7 +103,7 @@ namespace DP3 {
       // Fill the vector with station beam info from the input source (MS).
       // Only fill it for the given station names.
       // The default implementation throws an exception.
-      virtual void fillBeamInfo (vector<LOFAR::StationResponse::Station::Ptr>&,
+      virtual void fillBeamInfo (std::vector<LOFAR::StationResponse::Station::Ptr>&,
                                  const casacore::Vector<casacore::String>& antNames);
 #endif
 

--- a/DPPP/DPRun.cc
+++ b/DPPP/DPRun.cc
@@ -255,8 +255,8 @@ namespace DP3 {
         // Those parameters were always called msin and msout.
         // However, SAS/MAC cannot handle a parameter and a group with the same
         // name, hence one can also use msin.name and msout.name.
-        vector<string> inNames = parset.getStringVector ("msin.name",
-                                                         vector<string>());
+        std::vector<string> inNames = parset.getStringVector ("msin.name",
+                                                         std::vector<string>());
         if (inNames.empty()) {
           inNames = parset.getStringVector ("msin");
         }
@@ -266,7 +266,7 @@ namespace DP3 {
         // This is only possible if a single name is given.
         if (inNames.size() == 1) {
           if (inNames[0].find_first_of ("*?{['") != string::npos) {
-            vector<string> names;
+            std::vector<string> names;
             names.reserve (80);
             casacore::Path path(inNames[0]);
             casacore::String dirName(path.dirName());
@@ -301,10 +301,10 @@ namespace DP3 {
       casacore::String currentMSName (pathIn.absoluteName());
 
       // Create the other steps.
-      vector<string> steps = parset.getStringVector (prefix + "steps");
+      std::vector<string> steps = parset.getStringVector (prefix + "steps");
       lastStep = firstStep;
       DPStep::ShPtr step;
-      for (vector<string>::const_iterator iter = steps.begin();
+      for (std::vector<string>::const_iterator iter = steps.begin();
            iter != steps.end(); ++iter) {
         string prefix(*iter + '.');
         // The alphabetic part of the name is the default step type.

--- a/DPPP/DPStep.h
+++ b/DPPP/DPStep.h
@@ -240,9 +240,9 @@ namespace DP3 {
       virtual void show (std::ostream&) const;
 
       // Get the result.
-      const vector<DPBuffer>& get() const
+      const std::vector<DPBuffer>& get() const
         { return itsBuffers; }
-      vector<DPBuffer>& get()
+      std::vector<DPBuffer>& get()
         { return itsBuffers; }
 
       // Get the size of the result.
@@ -254,7 +254,7 @@ namespace DP3 {
         { itsSize = 0; }
 
     private:
-      vector<DPBuffer> itsBuffers;
+      std::vector<DPBuffer> itsBuffers;
       size_t           itsSize;
     };
 

--- a/DPPP/DemixInfo.h
+++ b/DPPP/DemixInfo.h
@@ -92,21 +92,21 @@ namespace DP3 {
       bool   solveBoth() const                   {return itsSolveBoth;}
       bool   doSubtract() const                  {return itsDoSubtract;}
       const BaselineSelection& selBL() const     {return itsSelBL;}
-      const vector<int>& uvwSplitIndex() const   {return itsUVWSplitIndex;}
+      const std::vector<int>& uvwSplitIndex() const   {return itsUVWSplitIndex;}
       const string& predictModelName() const     {return itsPredictModelName;}
       const string& demixModelName() const       {return itsDemixModelName;}
       const string& targetModelName() const      {return itsTargetModelName;}
-      const vector<string>& sourceNames() const  {return itsSourceNames;}
+      const std::vector<string>& sourceNames() const  {return itsSourceNames;}
       const Position& phaseRef() const           {return itsPhaseRef;}
-      const vector<Baseline>& baselines() const  {return itsBaselines;}
+      const std::vector<Baseline>& baselines() const  {return itsBaselines;}
       const casacore::Vector<bool> selTarget() const {return itsSelTarget;}
       const casacore::Vector<double>& freqDemix() const      {return itsFreqDemix;}
       const casacore::Vector<double>& freqSubtr() const      {return itsFreqSubtr;}
-      const vector<Patch::ConstPtr>& ateamList() const   {return itsAteamList;}
-      const vector<Patch::ConstPtr>& targetList() const  {return itsTargetList;}
-      const vector<Patch::ConstPtr>& ateamDemixList() const
+      const std::vector<Patch::ConstPtr>& ateamList() const   {return itsAteamList;}
+      const std::vector<Patch::ConstPtr>& targetList() const  {return itsTargetList;}
+      const std::vector<Patch::ConstPtr>& ateamDemixList() const
         {return itsAteamDemixList;}
-      const vector<Patch::ConstPtr>& targetDemixList() const
+      const std::vector<Patch::ConstPtr>& targetDemixList() const
         {return itsTargetDemixList;}
 
       // Get the baselines.
@@ -135,8 +135,8 @@ namespace DP3 {
 
     private:
       // Create a list of patches (and components).
-      vector<Patch::ConstPtr> makePatchList (const string& sdbName,
-                                             const vector<string>& patchNames);
+      std::vector<Patch::ConstPtr> makePatchList (const string& sdbName,
+                                             const std::vector<string>& patchNames);
 
       // Make the target list for demixing with a detailed model for the
       // possible Ateam sources in it.
@@ -146,11 +146,11 @@ namespace DP3 {
       DPInfo                  itsInfoSel;
       BaselineSelection       itsSelBL;
       BaselineSelection       itsSelBLTarget;
-      vector<int>             itsUVWSplitIndex;
+      std::vector<int>             itsUVWSplitIndex;
       string                  itsPredictModelName;
       string                  itsDemixModelName;
       string                  itsTargetModelName;
-      vector<string>          itsSourceNames;
+      std::vector<string>          itsSourceNames;
       double                  itsRatio1;
       double                  itsRatio2;
       double                  itsAteamAmplThreshold;
@@ -185,16 +185,16 @@ namespace DP3 {
       uint                    itsNTimeChunk;        //# nr chunks in parallel
       double                  itsTimeIntervalAvg;
       Position                itsPhaseRef;          //# original phaseref
-      vector<Baseline>        itsBaselines;
+      std::vector<Baseline>        itsBaselines;
       casacore::Vector<bool>      itsSelTarget;     //# baselines in target estimate
       casacore::Vector<double>    itsFreqDemix;
       casacore::Vector<double>    itsFreqSubtr;
-      vector<Patch::ConstPtr> itsAteamList;
-      vector<Patch::ConstPtr> itsTargetList;
-      vector<Patch::ConstPtr> itsAteamDemixList;
-      vector<Patch::ConstPtr> itsTargetDemixList;
-      vector<string>          itsAteamRemoved;
-      vector<string>          itsTargetReplaced;
+      std::vector<Patch::ConstPtr> itsAteamList;
+      std::vector<Patch::ConstPtr> itsTargetList;
+      std::vector<Patch::ConstPtr> itsAteamDemixList;
+      std::vector<Patch::ConstPtr> itsTargetDemixList;
+      std::vector<string>          itsAteamRemoved;
+      std::vector<string>          itsTargetReplaced;
     };
 
   } //# end namespace

--- a/DPPP/DemixWorker.h
+++ b/DPPP/DemixWorker.h
@@ -79,7 +79,7 @@ namespace DP3 {
       // Process the data in the input buffers and store the result in the
       // output buffers.
       void process (const DPBuffer* bufin, uint nbufin,
-                    DPBuffer* bufout, vector<double>* solutions,
+                    DPBuffer* bufout, std::vector<double>* solutions,
                     uint chunkNr);
 
       // Get the number of solves.
@@ -149,17 +149,17 @@ namespace DP3 {
       // Average the baseline UVWs in bufin and split them into UVW per station.
       // It returns the number of time averages.
       uint avgSplitUVW (const DPBuffer* bufin, uint nbufin,
-                        uint ntimeAvg, const vector<uint>& selbl);
+                        uint ntimeAvg, const std::vector<uint>& selbl);
 
       // Predict the target StokesI amplitude.
       // It applies the beam at each target patch.
-      void predictTarget (const vector<Patch::ConstPtr>& patchList,
+      void predictTarget (const std::vector<Patch::ConstPtr>& patchList,
                           uint ntime, double time, double timeStep);
 
       // Predict the StokesI amplitude of the Ateam patches and determine
       // which antennae and sources to use when demixing.
       // It applies the beam at each patch center.
-      void predictAteam (const vector<Patch::ConstPtr>& patchList,
+      void predictAteam (const std::vector<Patch::ConstPtr>& patchList,
                          uint ntime, double time, double timeStep);
 
       // Add the StokesI of itsPredictVis to ampl.
@@ -201,18 +201,18 @@ namespace DP3 {
 
       // Deproject the sources without a model.
       void deproject (casacore::Array<casacore::DComplex>& factors,
-                      vector<MultiResultStep*> avgResults,
+                      std::vector<MultiResultStep*> avgResults,
                       uint resultIndex);
 
       // Do the demixing.
-      void handleDemix (DPBuffer* bufout, vector<double>* solutions,
+      void handleDemix (DPBuffer* bufout, std::vector<double>* solutions,
                         double time, double timeStep);
 
       // Solve gains and subtract sources.
-      void demix (vector<double>* solutions, double time, double timeStep);
+      void demix (std::vector<double>* solutions, double time, double timeStep);
 
       // Add amplitude subtracted to the arrays for mean and stddev.
-      void addMeanM2 (const vector<float>& sourceAmpl, uint src);
+      void addMeanM2 (const std::vector<float>& sourceAmpl, uint src);
 
       // Merge the data of the selected baselines from the subtract buffer
       // into the full buffer.
@@ -221,14 +221,14 @@ namespace DP3 {
       //# Data members.
       int                                   itsWorkerNr;
       const DemixInfo*                      itsMix;
-      vector<PhaseShift*>                   itsOrigPhaseShifts;
+      std::vector<PhaseShift*>                   itsOrigPhaseShifts;
       //# Phase shift and average steps for demix.
-      vector<DPStep::ShPtr>                 itsOrigFirstSteps;
+      std::vector<DPStep::ShPtr>                 itsOrigFirstSteps;
       //# Result of phase shifting and averaging the directions of interest
       //# at the demix resolution.
-      vector<MultiResultStep*>              itsAvgResults;
-      vector<PhaseShift*>                   itsPhaseShifts;
-      vector<DPStep::ShPtr>                 itsFirstSteps;
+      std::vector<MultiResultStep*>              itsAvgResults;
+      std::vector<PhaseShift*>                   itsPhaseShifts;
+      std::vector<DPStep::ShPtr>                 itsFirstSteps;
       DPStep::ShPtr                         itsAvgStepSubtr;
       Filter                                itsFilter;
       Filter*                               itsFilterSubtr;
@@ -236,10 +236,10 @@ namespace DP3 {
       MultiResultStep*                      itsAvgResultFull;
       MultiResultStep*                      itsAvgResultSubtr;
       //# The sources to demix (excluding target).
-      vector<Patch::ConstPtr>               itsDemixList;
+      std::vector<Patch::ConstPtr>               itsDemixList;
 #ifdef HAVE_LOFAR_BEAM
       //# The info needed to calculate the station beams.
-      vector<LOFAR::StationResponse::Station::Ptr> itsAntBeamInfo;
+      std::vector<LOFAR::StationResponse::Station::Ptr> itsAntBeamInfo;
 #endif
       //# Measure objects unique to this worker (thread).
       //# This is needed because they are not thread-safe.
@@ -260,7 +260,7 @@ namespace DP3 {
       //# Buffer of demixing weights at the demix resolution. Each Array is a
       //# cube of shape #correlations x #channels x #baselines of matrices of
       //# shape #directions x #directions.
-      vector<casacore::Array<casacore::DComplex> >  itsFactors;
+      std::vector<casacore::Array<casacore::DComplex> >  itsFactors;
       //# Accumulator used for computing the demixing weights. The shape of this
       //# buffer is #correlations x #channels x #baselines x #directions
       //# x #directions (fastest axis first).
@@ -268,50 +268,50 @@ namespace DP3 {
       //# Buffer of demixing weights at the subtract resolution. Each Array is a
       //# cube of shape #correlations x #channels x #baselines of matrices of
       //# shape #directions x #directions.
-      vector<casacore::Array<casacore::DComplex> >  itsFactorsSubtr;
+      std::vector<casacore::Array<casacore::DComplex> >  itsFactorsSubtr;
 
       //# Variables for conversion of directions to ITRF.
       casacore::MeasFrame                       itsMeasFrame;
       casacore::MDirection::Convert             itsMeasConverter;
-      vector<LOFAR::StationResponse::matrix22c_t>  itsBeamValues;  //# [nst,nch]
+      std::vector<LOFAR::StationResponse::matrix22c_t>  itsBeamValues;  //# [nst,nch]
 
       //# Indices telling which Ateam sources to use.
-      vector<uint>                          itsSrcSet;
+      std::vector<uint>                          itsSrcSet;
       //# UVW per station per demix time slot
       casacore::Cube<double>                    itsStationUVW;  //# UVW per station
       casacore::Matrix<double>                  itsAvgUVW;      //# temp buffer
       casacore::Cube<dcomplex>                  itsPredictVis;  //# temp buffer
       //# #nfreq x #bl x #time StokesI amplitude per A-source.
-      vector<casacore::Cube<float> >            itsAteamAmpl;
+      std::vector<casacore::Cube<float> >            itsAteamAmpl;
       //# #bl x #src telling if baseline has sufficient Ateam flux.
       casacore::Matrix<bool>                    itsAteamAmplSel;
       //# #nfreq x #bl x #time StokesI amplitude of target.
       casacore::Cube<float>                     itsTargetAmpl;
       //# Temporary buffer to determine medians.
-      vector<float>                         itsTmpAmpl;
+      std::vector<float>                         itsTmpAmpl;
       //# Per A-source and for target the min and max amplitude.
-      vector<double>                        itsAteamMinAmpl;
-      vector<double>                        itsAteamMaxAmpl;
+      std::vector<double>                        itsAteamMinAmpl;
+      std::vector<double>                        itsAteamMaxAmpl;
       double                                itsTargetMinAmpl;
       double                                itsTargetMaxAmpl;
       //# Per A-source the stations to use (matching the minimum amplitude).
-      vector<vector<uint> >                 itsStationsToUse;
+      std::vector<std::vector<uint> >                 itsStationsToUse;
       casacore::Block<bool>                     itsSolveStation; //# solve station i?
       //# Per station and source the index in the unknowns vector.
       //# Note there are 8 unknowns (4 pol, ampl/phase) per source/station.
-      vector<vector<int> >                  itsUnknownsIndex;
+      std::vector<std::vector<int> >                  itsUnknownsIndex;
       //# The estimater (solver).
       EstimateNew                           itsEstimate;
       //# Variables for the predict.
       casacore::Matrix<double>                  itsUVW;
-      vector<casacore::Cube<dcomplex> >         itsModelVisDemix;
-      vector<casacore::Cube<dcomplex> >         itsModelVisSubtr;
+      std::vector<casacore::Cube<dcomplex> >         itsModelVisDemix;
+      std::vector<casacore::Cube<dcomplex> >         itsModelVisSubtr;
       uint                                  itsNTimeOut;
       uint                                  itsNTimeOutSubtr;
       uint                                  itsTimeIndex;
-      vector<float>                         itsObservedAmpl;
-      vector<float>                         itsSourceAmpl;
-      vector<float>                         itsSumSourceAmpl;
+      std::vector<float>                         itsObservedAmpl;
+      std::vector<float>                         itsSourceAmpl;
+      std::vector<float>                         itsSumSourceAmpl;
       //# Statistics
       uint                                  itsNrSolves;
       uint                                  itsNrConverged;

--- a/DPPP/Demixer.h
+++ b/DPPP/Demixer.h
@@ -51,7 +51,7 @@ namespace DP3 {
   namespace DPPP {
     // @ingroup NDPPP
 
-    typedef vector<Patch::ConstPtr> PatchList;
+    typedef std::vector<Patch::ConstPtr> PatchList;
 
     // This class is a DPStep class to subtract the strong A-team sources.
     // It is based on the demixing.py script made by Bas vd Tol and operates
@@ -108,7 +108,7 @@ namespace DP3 {
 
       // Deproject the sources without a model.
       void deproject (casacore::Array<casacore::DComplex>& factors,
-                      vector<MultiResultStep*> avgResults,
+                      std::vector<MultiResultStep*> avgResults,
                       uint resultIndex);
 
       // Solve gains and subtract sources.
@@ -131,12 +131,12 @@ namespace DP3 {
       size_t                                itsMaxIter;
       BaselineSelection                     itsSelBL;
       Filter                                itsFilter;
-      vector<PhaseShift*>                   itsPhaseShifts;
+      std::vector<PhaseShift*>                   itsPhaseShifts;
       //# Phase shift and average steps for demix.
-      vector<DPStep::ShPtr>                 itsFirstSteps;
+      std::vector<DPStep::ShPtr>                 itsFirstSteps;
       //# Result of phase shifting and averaging the directions of interest
       //# at the demix resolution.
-      vector<MultiResultStep*>              itsAvgResults;
+      std::vector<MultiResultStep*>              itsAvgResults;
       DPStep::ShPtr                         itsAvgStepSubtr;
       Filter*                               itsFilterSubtr;
       //# Result of averaging the target at the subtract resolution.
@@ -146,11 +146,11 @@ namespace DP3 {
       bool                                  itsIgnoreTarget;
       //# Name of the target. Empty if no model is available for the target.
       string                                itsTargetSource;
-      vector<string>                        itsSubtrSources;
-      vector<string>                        itsModelSources;
-      vector<string>                        itsExtraSources;
-      vector<string>                        itsAllSources;
-//      vector<double>                        itsCutOffs;
+      std::vector<string>                        itsSubtrSources;
+      std::vector<string>                        itsModelSources;
+      std::vector<string>                        itsExtraSources;
+      std::vector<string>                        itsAllSources;
+//      std::vector<double>                        itsCutOffs;
       bool                                  itsPropagateSolutions;
       uint                                  itsNDir;
       uint                                  itsNModel;
@@ -179,7 +179,7 @@ namespace DP3 {
       //# Buffer of demixing weights at the demix resolution. Each Array is a
       //# cube of shape #correlations x #channels x #baselines of matrices of
       //# shape #directions x #directions.
-      vector<casacore::Array<casacore::DComplex> >  itsFactors;
+      std::vector<casacore::Array<casacore::DComplex> >  itsFactors;
 
       //# Accumulator used for computing the demixing weights. The shape of this
       //# buffer is #correlations x #channels x #baselines x #directions
@@ -188,16 +188,16 @@ namespace DP3 {
       //# Buffer of demixing weights at the subtract resolution. Each Array is a
       //# cube of shape #correlations x #channels x #baselines of matrices of
       //# shape #directions x #directions.
-      vector<casacore::Array<casacore::DComplex> >  itsFactorsSubtr;
+      std::vector<casacore::Array<casacore::DComplex> >  itsFactorsSubtr;
 
       PatchList                             itsPatchList;
       Position                              itsPhaseRef;
-      vector<Baseline>                      itsBaselines;
-      vector<int>                           itsUVWSplitIndex;
+      std::vector<Baseline>                      itsBaselines;
+      std::vector<int>                           itsUVWSplitIndex;
       casacore::Vector<double>                  itsFreqDemix;
       casacore::Vector<double>                  itsFreqSubtr;
-      vector<double>                        itsUnknowns;
-      vector<double>                        itsPrevSolution;
+      std::vector<double>                        itsUnknowns;
+      std::vector<double>                        itsPrevSolution;
       uint                                  itsTimeIndex;
       uint                                  itsNConverged;
       FlagCounter                           itsFlagCounter;

--- a/DPPP/Filter.h
+++ b/DPPP/Filter.h
@@ -160,7 +160,7 @@ namespace DP3 {
         { return itsDoSelect; }
 
       // Get the indices of the selected baselines.
-      const vector<uint>& getIndicesBL() const
+      const std::vector<uint>& getIndicesBL() const
         { return itsSelBL; }
 
       // Get the buffer.
@@ -195,7 +195,7 @@ namespace DP3 {
       bool              itsRemoveAnt;     //# Remove from ANTENNA table?
       BaselineSelection itsBaselines;
       uint              itsStartChan;
-      vector<uint>      itsSelBL;         //# Index of baselines to select
+      std::vector<uint>      itsSelBL;         //# Index of baselines to select
       bool              itsDoSelect;      //# Any selection?
       NSTimer           itsTimer;
     };

--- a/DPPP/FlagCounter.h
+++ b/DPPP/FlagCounter.h
@@ -80,11 +80,11 @@ namespace DP3 {
       void add (const FlagCounter& that);
 
       // Get the counts.
-      const vector<int64_t>& baselineCounts() const
+      const std::vector<int64_t>& baselineCounts() const
         { return itsBLCounts; }
-      const vector<int64_t>& channelCounts() const
+      const std::vector<int64_t>& channelCounts() const
         { return itsChanCounts; }
-      const vector<int64_t>& correlationCounts() const
+      const std::vector<int64_t>& correlationCounts() const
         { return itsCorrCounts; }
 
       // Print the counts and optionally save percentages in a table.
@@ -112,9 +112,9 @@ namespace DP3 {
       string        itsSaveName;
       double        itsWarnPerc;
       bool          itsShowFF;
-      vector<int64_t> itsBLCounts;
-      vector<int64_t> itsChanCounts;
-      vector<int64_t> itsCorrCounts;
+      std::vector<int64_t> itsBLCounts;
+      std::vector<int64_t> itsChanCounts;
+      std::vector<int64_t> itsCorrCounts;
     };
 
   } //# end namespace

--- a/DPPP/MSReader.cc
+++ b/DPPP/MSReader.cc
@@ -108,7 +108,7 @@ namespace DP3 {
       // See if a selection on band needs to be done.
       // We assume that DATA_DESC_ID and SPW_ID map 1-1.
       if (itsSpw >= 0) {
-        DPLOG_INFO_STR (" MSReader selecting spectral window " + to_string(itsSpw) + " ...");
+        DPLOG_INFO_STR (" MSReader selecting spectral window " + std::to_string(itsSpw) + " ...");
         Table subset = itsSelMS (itsSelMS.col("DATA_DESC_ID") == itsSpw);
         // If not all is selected, use the selection.
         if (subset.nrow() < itsSelMS.nrow()) {

--- a/DPPP/MSReader.h
+++ b/DPPP/MSReader.h
@@ -189,7 +189,7 @@ namespace DP3 {
 #ifdef HAVE_LOFAR_BEAM
       // Fill the vector with station beam info from the input MS.
       // Only fill it for the given station names.
-      virtual void fillBeamInfo (vector<LOFAR::StationResponse::Station::Ptr>&,
+      virtual void fillBeamInfo (std::vector<LOFAR::StationResponse::Station::Ptr>&,
                                  const casacore::Vector<casacore::String>& antNames);
 #endif
       

--- a/DPPP/MedFlagger.h
+++ b/DPPP/MedFlagger.h
@@ -103,11 +103,11 @@ namespace DP3 {
       // Flag for the entry at the given index.
       // Use the given time entries for the medians.
       // Process the result in the next step.
-      void flag (uint index, const vector<uint>& timeEntries);
+      void flag (uint index, const std::vector<uint>& timeEntries);
 
       // Compute the median factors for given baseline, channel, and
       // correlation.
-      void computeFactors (const vector<uint>& timeEntries,
+      void computeFactors (const std::vector<uint>& timeEntries,
                            uint bl, int chan, int corr,
                            int nchan, int ncorr,
                            float& Z1, float& Z2,
@@ -124,23 +124,23 @@ namespace DP3 {
       string           itsThresholdStr;
       string           itsFreqWindowStr;
       string           itsTimeWindowStr;
-      vector<float>    itsThresholdArr;  //# threshold per baseline
-      vector<uint>     itsFreqWindowArr; //# freq window size per baseline
-      vector<uint>     itsTimeWindowArr; //# time window size per baseline
+      std::vector<float>    itsThresholdArr;  //# threshold per baseline
+      std::vector<uint>     itsFreqWindowArr; //# freq window size per baseline
+      std::vector<uint>     itsTimeWindowArr; //# time window size per baseline
       float            itsThreshold;
       uint             itsFreqWindow;
       uint             itsTimeWindow;
       uint             itsNTimes;
       uint             itsNTimesDone;
-      vector<uint>     itsFlagCorr;
+      std::vector<uint>     itsFlagCorr;
       bool             itsApplyAutoCorr;
-      vector<int>      itsAutoCorrIndex; //# baseline index of autocorrelations
+      std::vector<int>      itsAutoCorrIndex; //# baseline index of autocorrelations
       uint             itsNrAutoCorr;
       double           itsMinBLength;    //# minimum baseline length
       double           itsMaxBLength;    //# maximum baseline length
-      vector<double>   itsBLength;       //# length of each baseline
-      vector<DPBuffer> itsBuf;
-      vector<casacore::Cube<float> > itsAmpl; //# amplitudes of the data
+      std::vector<double>   itsBLength;       //# length of each baseline
+      std::vector<DPBuffer> itsBuf;
+      std::vector<casacore::Cube<float> > itsAmpl; //# amplitudes of the data
       FlagCounter      itsFlagCounter;
       NSTimer          itsTimer;
       NSTimer          itsComputeTimer;  //# move/median timer

--- a/DPPP/MultiMSReader.h
+++ b/DPPP/MultiMSReader.h
@@ -130,7 +130,7 @@ namespace DP3 {
     public:
       // Construct the object for the given MS.
       // Parameters are obtained from the parset using the given prefix.
-      MultiMSReader (const vector<string>& msNames,
+      MultiMSReader (const std::vector<string>& msNames,
                      const ParameterSet&, const string& prefix);
 
       virtual ~MultiMSReader();
@@ -186,10 +186,10 @@ namespace DP3 {
       bool                  itsOrderMS;   //# sort multi MS in order of freq?
       int                   itsFirst;     //# first valid MSReader (<0 = none)
       int                   itsNMissing;  //# nr of missing MSs
-      vector<string>        itsMSNames;
-      vector<MSReader*>     itsReaders;   //# same as itsSteps
-      vector<DPStep::ShPtr> itsSteps;     //# used for automatic destruction
-      vector<DPBuffer>      itsBuffers;
+      std::vector<string>        itsMSNames;
+      std::vector<MSReader*>     itsReaders;   //# same as itsSteps
+      std::vector<DPStep::ShPtr> itsSteps;     //# used for automatic destruction
+      std::vector<DPBuffer>      itsBuffers;
       uint                  itsFillNChan; //# nr of chans for missing MSs
       FlagCounter           itsFlagCounter;
       bool                  itsRegularChannels; // Are resulting channels regularly spaced

--- a/DPPP/OneApplyCal.h
+++ b/DPPP/OneApplyCal.h
@@ -134,7 +134,7 @@ namespace DP3 {
       uint             itsCount; // number of steps
 
       // Expressions to search for in itsParmDB
-      vector<casacore::String>   itsParmExprs;
+      std::vector<casacore::String>   itsParmExprs;
 
       // parameters, numparms, antennas, time x frequency
       casacore::Cube<casacore::DComplex> itsParms;

--- a/DPPP/PhaseShift.h
+++ b/DPPP/PhaseShift.h
@@ -58,7 +58,7 @@ namespace DP3 {
       // This is a constructor for Demixer where the phasecenter has the
       // given default value.
       PhaseShift (DPInput*, const ParameterSet&, const string& prefix,
-                  const vector<string>& defVal);
+                  const std::vector<string>& defVal);
 
       virtual ~PhaseShift();
 
@@ -89,7 +89,7 @@ namespace DP3 {
         { return itsPhasors; }
 
       // Get the phase center.
-      const vector<string>& getPhaseCenter() const
+      const std::vector<string>& getPhaseCenter() const
         { return itsCenter; }
 
     private:
@@ -101,8 +101,8 @@ namespace DP3 {
       DPInput*             itsInput;
       string               itsName;
       DPBuffer             itsBuf;
-      vector<string>       itsCenter;
-      vector<double>       itsFreqC;      //# freq/C
+      std::vector<string>       itsCenter;
+      std::vector<double>       itsFreqC;      //# freq/C
       casacore::Matrix<double> itsMat1;       //# TT in phasehift.py
       double               itsXYZ[3];     //# numpy.dot((w-w1).T, T)
       casacore::Matrix<casacore::DComplex> itsPhasors; //# phase factor per chan,bl

--- a/DPPP/PreFlagger.h
+++ b/DPPP/PreFlagger.h
@@ -143,7 +143,7 @@ namespace DP3 {
         bool matchTime (double time, uint timeSlot) const;
 
         // Test if the value matches one of the ranges in the vector.
-        bool matchRange (double v, const vector<double>& ranges) const;
+        bool matchRange (double v, const std::vector<double>& ranges) const;
 
         // Clear itsMatchBL for mismatching baselines.
         // If returns false if no matches were found.
@@ -180,7 +180,7 @@ namespace DP3 {
         // must be given with .. or +-.
         // <tt>asTime=true</tt> means that the strings should contain times,
         // otherwise date/times.
-        vector<double> fillTimes (const vector<string>& str, bool asTime,
+        std::vector<double> fillTimes (const std::vector<string>& str, bool asTime,
                                   bool canEndBeforeStart);
 
         // Read the string as time or date/time and convert to seconds.
@@ -200,7 +200,7 @@ namespace DP3 {
         // default for non-given correlations.
         // If the parm value is a single value, use it for all correlations.
         // <br>doFlag is set if values are given.
-        vector<float> fillValuePerCorr (const ParameterValue& value,
+        std::vector<float> fillValuePerCorr (const ParameterValue& value,
                                         float defVal, bool& doFlag);
 
         // Handle the frequency ranges given and determine which channels
@@ -217,7 +217,7 @@ namespace DP3 {
 
         // Convert a PSet expression to Reversed Polish Notation in itsRpn.
         // It returns the names of all PSets.
-        vector<string> exprToRpn (const string& expr);
+        std::vector<string> exprToRpn (const string& expr);
 
         //# Data members of PreFlagger::PSet.
         DPInput*           itsInput;
@@ -237,32 +237,32 @@ namespace DP3 {
         double             itsMinUV;    //# minimum UV distance; <0 means ignore
         double             itsMaxUV;    //# maximum UV distance; <0 means ignore
         casacore::Matrix<bool> itsFlagBL;   //# true = flag baseline [i,j]
-        vector<double>     itsAzimuth;  //# azimuth ranges to be flagged
-        vector<double>     itsElevation;//# elevation ranges to be flagged
-        vector<double>     itsTimes;    //# time of day ranges to be flagged
-        vector<double>     itsLST;      //# sidereal time ranges to be flagged
-        vector<double>     itsATimes;   //# absolute time ranges to be flagged
-        vector<double>     itsRTimes;   //# relative time ranges to be flagged
-        vector<uint>       itsTimeSlot; //# time slots to be flagged
-        vector<float>      itsAmplMin;  //# minimum amplitude for each corr
-        vector<float>      itsAmplMax;  //# maximum amplitude for each corr
-        vector<float>      itsPhaseMin; //# minimum phase for each corr
-        vector<float>      itsPhaseMax; //# maximum phase for each corr
-        vector<float>      itsRealMin;  //# minimum real for each corr
-        vector<float>      itsRealMax;  //# maximum real for each corr
-        vector<float>      itsImagMin;  //# minimum imaginary for each corr
-        vector<float>      itsImagMax;  //# maximum imaginary for each corr
-        vector<uint>       itsChannels; //# channels to be flagged.
-        vector<string>     itsStrChan;  //# channel ranges to be flagged.
-        vector<string>     itsStrFreq;  //# frequency ranges to be flagged
-        vector<string>     itsStrTime;  //# time ranges to be flagged
-        vector<string>     itsStrLST;   //# LST ranges to be flagged
-        vector<string>     itsStrATime; //# absolute time ranges to be flagged
-        vector<string>     itsStrRTime; //# relative time ranges to be flagged
-        vector<string>     itsStrAzim;  //# azimuth ranges to be flagged
-        vector<string>     itsStrElev;  //# elevation ranges to be flagged
-        vector<int>         itsRpn;     //# PSet expression in RPN form
-        vector<PSet::ShPtr> itsPSets;   //# PSets used in itsRpn
+        std::vector<double>     itsAzimuth;  //# azimuth ranges to be flagged
+        std::vector<double>     itsElevation;//# elevation ranges to be flagged
+        std::vector<double>     itsTimes;    //# time of day ranges to be flagged
+        std::vector<double>     itsLST;      //# sidereal time ranges to be flagged
+        std::vector<double>     itsATimes;   //# absolute time ranges to be flagged
+        std::vector<double>     itsRTimes;   //# relative time ranges to be flagged
+        std::vector<uint>       itsTimeSlot; //# time slots to be flagged
+        std::vector<float>      itsAmplMin;  //# minimum amplitude for each corr
+        std::vector<float>      itsAmplMax;  //# maximum amplitude for each corr
+        std::vector<float>      itsPhaseMin; //# minimum phase for each corr
+        std::vector<float>      itsPhaseMax; //# maximum phase for each corr
+        std::vector<float>      itsRealMin;  //# minimum real for each corr
+        std::vector<float>      itsRealMax;  //# maximum real for each corr
+        std::vector<float>      itsImagMin;  //# minimum imaginary for each corr
+        std::vector<float>      itsImagMax;  //# maximum imaginary for each corr
+        std::vector<uint>       itsChannels; //# channels to be flagged.
+        std::vector<string>     itsStrChan;  //# channel ranges to be flagged.
+        std::vector<string>     itsStrFreq;  //# frequency ranges to be flagged
+        std::vector<string>     itsStrTime;  //# time ranges to be flagged
+        std::vector<string>     itsStrLST;   //# LST ranges to be flagged
+        std::vector<string>     itsStrATime; //# absolute time ranges to be flagged
+        std::vector<string>     itsStrRTime; //# relative time ranges to be flagged
+        std::vector<string>     itsStrAzim;  //# azimuth ranges to be flagged
+        std::vector<string>     itsStrElev;  //# elevation ranges to be flagged
+        std::vector<int>         itsRpn;     //# PSet expression in RPN form
+        std::vector<PSet::ShPtr> itsPSets;   //# PSets used in itsRpn
         casacore::Matrix<bool>  itsChanFlags; //# flags for channels to be flagged
         casacore::Cube<bool>    itsFlags;
         casacore::Block<bool>   itsMatchBL; //# true = baseline in buffer matches 

--- a/DPPP/Predict.h
+++ b/DPPP/Predict.h
@@ -73,11 +73,11 @@ namespace DP3 {
 
       // Constructor with explicit sourcelist
       Predict (DPInput*, const ParameterSet&, const string& prefix,
-               const vector<string>& sourcePatterns);
+               const std::vector<string>& sourcePatterns);
 
       // The actual constructor
       void init (DPInput*, const ParameterSet&, const string& prefix,
-                 const vector<string>& sourcePatterns);
+                 const std::vector<string>& sourcePatterns);
 
       // Set the applycal substep
       void setApplyCal(DPInput*, const ParameterSet&, const string& prefix);
@@ -110,7 +110,7 @@ namespace DP3 {
       virtual void showTimings (std::ostream&, double duration) const;
 
       // Prepare the sources
-      void setSources(const vector<string>& sourcePatterns);
+      void setSources(const std::vector<string>& sourcePatterns);
 
       // Return the direction of the first patch
       std::pair<double, double> getFirstDirection() const;
@@ -146,29 +146,29 @@ namespace DP3 {
 
       uint             itsDebugLevel;
 
-      vector<Baseline> itsBaselines;
+      std::vector<Baseline> itsBaselines;
 
       // Vector containing info on converting baseline uvw to station uvw
-      vector<int>      itsUVWSplitIndex;
+      std::vector<int>      itsUVWSplitIndex;
 
       // UVW coordinates per station (3 coordinates per station)
       casacore::Matrix<double>   itsUVW;
 
 #ifdef HAVE_LOFAR_BEAM
       // The info needed to calculate the station beams.
-      vector<vector<LOFAR::StationResponse::Station::Ptr> > itsAntBeamInfo;
-      vector<vector<LOFAR::StationResponse::matrix22c_t> >  itsBeamValues;
+      std::vector<std::vector<LOFAR::StationResponse::Station::Ptr> > itsAntBeamInfo;
+      std::vector<std::vector<LOFAR::StationResponse::matrix22c_t> >  itsBeamValues;
       BeamCorrectionMode itsBeamMode;
 #endif
-      vector<casacore::MeasFrame>                    itsMeasFrames;
-      vector<casacore::MDirection::Convert>          itsMeasConverters;
+      std::vector<casacore::MeasFrame>                    itsMeasFrames;
+      std::vector<casacore::MDirection::Convert>          itsMeasConverters;
 
       std::string itsDirectionsStr; // Definition of patches, to pass to applycal
-      vector<Patch::ConstPtr> itsPatchList;
-      vector<Source> itsSourceList;
+      std::vector<Patch::ConstPtr> itsPatchList;
+      std::vector<Source> itsSourceList;
 
-      vector<casacore::Cube<dcomplex> > itsModelVis; // one for every thread
-      vector<casacore::Cube<dcomplex> > itsModelVisPatch;
+      std::vector<casacore::Cube<dcomplex> > itsModelVis; // one for every thread
+      std::vector<casacore::Cube<dcomplex> > itsModelVisPatch;
 
       NSTimer          itsTimer;
       NSTimer          itsTimerPredict;

--- a/DPPP/ScaleData.h
+++ b/DPPP/ScaleData.h
@@ -82,15 +82,15 @@ namespace DP3 {
 
     private:
       // Fill the scale factors for stations having different nr of tiles.
-      void fillSizeScaleFactors (uint nNominal, vector<double>& fact);
+      void fillSizeScaleFactors (uint nNominal, std::vector<double>& fact);
 
       //# Data members.
       string             itsName;
       bool               itsScaleSizeGiven;
       bool               itsScaleSize;
-      vector<string>     itsStationExp;  // station regex strings
-      vector<string>     itsCoeffStr;    // coeff per station regex
-      vector<vector<double> > itsStationFactors; // scale factor per station,freq
+      std::vector<string>     itsStationExp;  // station regex strings
+      std::vector<string>     itsCoeffStr;    // coeff per station regex
+      std::vector<std::vector<double> > itsStationFactors; // scale factor per station,freq
       casacore::Cube<double> itsFactors;     // scale factor per baseline,freq,pol
       NSTimer            itsTimer;
     };

--- a/DPPP/SourceDBUtil.cc
+++ b/DPPP/SourceDBUtil.cc
@@ -41,12 +41,12 @@ using BBS::SourceData;
 using BBS::SourceInfo;
 
 
-vector<Patch::ConstPtr> makePatches(SourceDB &sourceDB,
-                                    const vector<string> &patchNames,
+std::vector<Patch::ConstPtr> makePatches(SourceDB &sourceDB,
+                                    const std::vector<string> &patchNames,
                                     uint nModel)
 {
   // Create a component list for each patch name.
-  vector<vector<ModelComponent::Ptr> > componentsList(nModel);
+  std::vector<std::vector<ModelComponent::Ptr> > componentsList(nModel);
 
   // Loop over all sources.
   sourceDB.lock();
@@ -126,7 +126,7 @@ vector<Patch::ConstPtr> makePatches(SourceDB &sourceDB,
   }
   sourceDB.unlock();
 
-  vector<Patch::ConstPtr> patchList;
+  std::vector<Patch::ConstPtr> patchList;
   patchList.reserve (componentsList.size());
   for (uint i=0; i<componentsList.size(); ++i) {
     if (componentsList[i].empty())
@@ -135,7 +135,7 @@ vector<Patch::ConstPtr> makePatches(SourceDB &sourceDB,
     Patch::Ptr ppatch(new Patch(patchNames[i],
                                 componentsList[i].begin(),
                                 componentsList[i].end()));
-    vector<BBS::PatchInfo> patchInfo(sourceDB.getPatchInfo(-1, patchNames[i]));
+    std::vector<BBS::PatchInfo> patchInfo(sourceDB.getPatchInfo(-1, patchNames[i]));
     assert (patchInfo.size() == 1);
     // Set the position and apparent flux of the patch.
     Position patchPosition;
@@ -176,16 +176,16 @@ makeSourceList (const std::vector<Patch::ConstPtr>& patchList) {
 }
 
 
-vector<Patch::ConstPtr> makeOnePatchPerComponent(
-    const vector<Patch::ConstPtr>& patchList) {
+std::vector<Patch::ConstPtr> makeOnePatchPerComponent(
+    const std::vector<Patch::ConstPtr>& patchList) {
     size_t numComponents=0;
-    vector<Patch::ConstPtr>::const_iterator patchIt;
+    std::vector<Patch::ConstPtr>::const_iterator patchIt;
 
     for (patchIt=patchList.begin();patchIt!=patchList.end();++patchIt) {
         numComponents+=(*patchIt)->nComponents();
     }
 
-    vector<Patch::ConstPtr> largePatchList;
+    std::vector<Patch::ConstPtr> largePatchList;
     largePatchList.reserve(numComponents);
 
     for (patchIt=patchList.begin();patchIt!=patchList.end();++patchIt) {
@@ -210,7 +210,7 @@ vector<Patch::ConstPtr> makeOnePatchPerComponent(
 }
 
 
-vector<string> makePatchList(SourceDB &sourceDB, vector<string> patterns)
+std::vector<string> makePatchList(SourceDB &sourceDB, std::vector<string> patterns)
 {
     if(patterns.empty())
     {
@@ -218,7 +218,7 @@ vector<string> makePatchList(SourceDB &sourceDB, vector<string> patterns)
     }
 
     std::set<string> patches;
-    vector<string>::iterator it = patterns.begin();
+    std::vector<string>::iterator it = patterns.begin();
     while(it != patterns.end())
     {
         if(!it->empty() && (*it)[0] == '@')
@@ -228,18 +228,18 @@ vector<string> makePatchList(SourceDB &sourceDB, vector<string> patterns)
         }
         else
         {
-            vector<string> match(sourceDB.getPatches(-1, *it));
+            std::vector<string> match(sourceDB.getPatches(-1, *it));
             patches.insert(match.begin(), match.end());
             ++it;
         }
     }
 
-    return vector<string>(patches.begin(), patches.end());
+    return std::vector<string>(patches.begin(), patches.end());
 }
 
 
 bool checkPolarized(SourceDB &sourceDB,
-                    const vector<string> &patchNames,
+                    const std::vector<string> &patchNames,
                     uint nModel)
 {
   bool polarized = false;

--- a/DPPP/StationAdder.h
+++ b/DPPP/StationAdder.h
@@ -94,9 +94,9 @@ namespace DP3 {
       // with ! or ^ meaning that the the matches are discarded. In this
       // way first a broad pattern can be given, which can be narrowed down.
       // A warning is given if a pattern does not match any station name.
-      static vector<int> getMatchingStations
+      static std::vector<int> getMatchingStations
       (const casacore::Vector<casacore::String>& antennaNames,
-       const vector<string>& patterns);
+       const std::vector<string>& patterns);
 
     private:
       // Update the beam info subtables.
@@ -109,8 +109,8 @@ namespace DP3 {
       DPBuffer        itsBuf;
       DPBuffer        itsBufTmp;
       ParameterRecord itsStatRec;     // stations definitions
-      vector<casacore::Vector<int> > itsParts;  // the stations in each superstation
-      vector<vector<int> > itsBufRows; // old baseline rows in each new baseline
+      std::vector<casacore::Vector<int> > itsParts;  // the stations in each superstation
+      std::vector<std::vector<int> > itsBufRows; // old baseline rows in each new baseline
       uint            itsMinNPoint  ;  // flag data if too few unflagged data
       bool            itsMakeAutoCorr; // also form new auto-correlations?
       bool            itsSumAutoCorr;  // sum auto- or cross-correlations?

--- a/DPPP/UVWCalculator.h
+++ b/DPPP/UVWCalculator.h
@@ -61,7 +61,7 @@ namespace DP3 {
       // and station positions.
       UVWCalculator (const casacore::MDirection& phaseDir,
                      const casacore::MPosition& arrayPosition,
-                     const vector<casacore::MPosition>& stationPositions);
+                     const std::vector<casacore::MPosition>& stationPositions);
 
       // get the UVW coordinates for the given baseline and time.
       casacore::Vector<double> getUVW (uint ant1, uint ant2, double time);
@@ -72,8 +72,8 @@ namespace DP3 {
       casacore::MDirection::Convert     itsDirToJ2000;   //# direction to J2000
       casacore::MBaseline::Convert      itsBLToJ2000;    //# convert ITRF to J2000
       casacore::MeasFrame               itsFrame;
-      vector<casacore::MBaseline>       itsAntMB;
-      vector<casacore::Vector<double> > itsAntUvw;
+      std::vector<casacore::MBaseline>       itsAntMB;
+      std::vector<casacore::Vector<double> > itsAntUvw;
       casacore::Block<bool>             itsUvwFilled;
       double                        itsLastTime;
     };

--- a/DPPP/UVWFlagger.h
+++ b/DPPP/UVWFlagger.h
@@ -83,10 +83,10 @@ namespace DP3 {
 
     private:
       // Test if uvw matches a range in meters.
-      bool testUVWm (double uvw, const vector<double>& ranges);
+      bool testUVWm (double uvw, const std::vector<double>& ranges);
 
       // Set flags for channels where uvw (in m) matches a range in wavelengths.
-      void testUVWl (double uvw, const vector<double>& ranges,
+      void testUVWl (double uvw, const std::vector<double>& ranges,
                      bool* flagPtr, uint nrcorr);
 
       // Return a vector with UVW ranges.
@@ -95,7 +95,7 @@ namespace DP3 {
       // (min and max are also turned into a range).
       // Optionally the values are squared to avoid having to take a sqrt
       // of the data's UVW coordinates.
-      vector<double> fillUVW (const ParameterSet& parset,
+      std::vector<double> fillUVW (const ParameterSet& parset,
                               const string& prefix,
                               const string& name,
                               bool square);
@@ -114,16 +114,16 @@ namespace DP3 {
       bool                 itsIsDegenerate;
 
       casacore::Vector<double> itsRecWavel; //# reciprokes of wavelengths
-      vector<double>       itsRangeUVm; //# UV ranges (in m) to be flagged
-      vector<double>       itsRangeUm;  //# U  ranges (in m) to be flagged
-      vector<double>       itsRangeVm;  //# V  ranges (in m) to be flagged
-      vector<double>       itsRangeWm;  //# W  ranges (in m) to be flagged
-      vector<double>       itsRangeUVl; //# UV ranges (in wavel) to be flagged
-      vector<double>       itsRangeUl;  //# U  ranges (in wavel) to be flagged
-      vector<double>       itsRangeVl;  //# V  ranges (in wavel) to be flagged
-      vector<double>       itsRangeWl;  //# W  ranges (in wavel) to be flagged
+      std::vector<double>       itsRangeUVm; //# UV ranges (in m) to be flagged
+      std::vector<double>       itsRangeUm;  //# U  ranges (in m) to be flagged
+      std::vector<double>       itsRangeVm;  //# V  ranges (in m) to be flagged
+      std::vector<double>       itsRangeWm;  //# W  ranges (in m) to be flagged
+      std::vector<double>       itsRangeUVl; //# UV ranges (in wavel) to be flagged
+      std::vector<double>       itsRangeUl;  //# U  ranges (in wavel) to be flagged
+      std::vector<double>       itsRangeVl;  //# V  ranges (in wavel) to be flagged
+      std::vector<double>       itsRangeWl;  //# W  ranges (in wavel) to be flagged
       UVWCalculator        itsUVWCalc;
-      vector<string>       itsCenter;
+      std::vector<string>       itsCenter;
       NSTimer              itsTimer;
       NSTimer              itsUVWTimer;
       FlagCounter          itsFlagCounter;

--- a/ParmDB/Parm.h
+++ b/ParmDB/Parm.h
@@ -80,11 +80,11 @@ namespace BBS {
 
     // Get the coefficients for the given location in the solve grid.
     // The solve grid must have been set before.
-    vector<double> getCoeff (const Location&, bool useMask=true);
+    std::vector<double> getCoeff (const Location&, bool useMask=true);
 
     // Get the errors for the given location in the solve grid.
     // The solve grid must have been set before.
-    vector<double> getErrors (const Location&, bool useMask=true);
+    std::vector<double> getErrors (const Location&, bool useMask=true);
 
     // Set the coefficients for the given location in the solve grid.
     // If given, the errors are set too.
@@ -101,7 +101,7 @@ namespace BBS {
 
     // Get the perturbations for the coefficients.
     // The possible mask is applied.
-    const vector<double>& getPerturbations() const
+    const std::vector<double>& getPerturbations() const
       { return itsPerturbations; }
 
     // Get a particular perturbation.
@@ -132,11 +132,11 @@ namespace BBS {
     // Otherwise only the first array in the vector is filled in.
     // As above, the shape of the array is normally [nx,ny],
     // but can be [1,1] if constant.
-    void getResult (vector<casacore::Array<double> >& result,
+    void getResult (std::vector<casacore::Array<double> >& result,
                     const Grid& predictGrid, bool perturb);
 
     // Form the vector from values and mask.
-    static vector<double> copyValues (const casacore::Array<double>& values,
+    static std::vector<double> copyValues (const casacore::Array<double>& values,
                                       const casacore::Array<bool>& mask,
                                       bool useMask);
 
@@ -144,7 +144,7 @@ namespace BBS {
     static void getResultCoeff (casacore::Array<double>* resultVec,
                                 const Grid& predictGrid,
                                 const ParmValueSet& pvset,
-                                const vector<double>& perturbations,
+                                const std::vector<double>& perturbations,
                                 AxisMappingCache& axisMappingCache);
 
     // Get the result for a single ParmValue with an array of scalars.
@@ -174,7 +174,7 @@ namespace BBS {
     ParmCache*     itsCache;
     ParmId         itsParmId;
     Grid           itsSolveGrid;
-    vector<double> itsPerturbations;
+    std::vector<double> itsPerturbations;
   };
 
   // @}

--- a/ParmDB/ParmCache.h
+++ b/ParmDB/ParmCache.h
@@ -111,7 +111,7 @@ namespace BBS {
 
     ParmSet*             itsParmSet;
     Box                  itsWorkDomain;
-    vector<ParmValueSet> itsValueSets;
+    std::vector<ParmValueSet> itsValueSets;
     AxisMappingCache     itsAxisCache;
   };
 

--- a/ParmDB/ParmDB.h
+++ b/ParmDB/ParmDB.h
@@ -82,11 +82,11 @@ namespace BBS {
     // </group>
 
     // Get the default step values for the axes.
-    const vector<double>& getDefaultSteps() const
+    const std::vector<double>& getDefaultSteps() const
       { return itsDefSteps; }
 
     // Set the default step values.
-    virtual void setDefaultSteps (const vector<double>&) = 0;
+    virtual void setDefaultSteps (const std::vector<double>&) = 0;
 
     // Get the parameter values for the given parameters and domain.
     // Only * and ? should be used in the pattern (no [] and {}).
@@ -97,9 +97,9 @@ namespace BBS {
 
     // Get the parameter values for the given parameters and domain.
     // The parmids form the indices in the result vector.
-    virtual void getValues (vector<ParmValueSet>& values,
-                            const vector<uint>& nameIds,
-                            const vector<ParmId>& parmIds,
+    virtual void getValues (std::vector<ParmValueSet>& values,
+                            const std::vector<uint>& nameIds,
+                            const std::vector<ParmId>& parmIds,
                             const Box& domain) = 0;
 
     // Put the values for the given parameter name and id.
@@ -182,7 +182,7 @@ namespace BBS {
     int        itsSeqNr;
     bool       itsDefFilled;
     ParmMap    itsDefValues;
-    vector<double> itsDefSteps;
+    std::vector<double> itsDefSteps;
   };
 
 
@@ -230,11 +230,11 @@ namespace BBS {
     // </group>
 
     // Get the default step values for the axes.
-    const vector<double>& getDefaultSteps() const
+    const std::vector<double>& getDefaultSteps() const
       { return itsRep->getDefaultSteps(); }
 
     // Set the default step values.
-    void setDefaultSteps (const vector<double>& steps)
+    void setDefaultSteps (const std::vector<double>& steps)
       { itsRep->setDefaultSteps (steps); }
 
     // Get the parameter values for the given parameters and domain.
@@ -246,9 +246,9 @@ namespace BBS {
 
     // Get the parameter values for the given parameters and domain.
     // The parmids form the indices in the result vector.
-    void getValues (vector<ParmValueSet>& values,
-                    const vector<uint>& nameIds,
-                    const vector<ParmId>& parmIds,
+    void getValues (std::vector<ParmValueSet>& values,
+                    const std::vector<uint>& nameIds,
+                    const std::vector<ParmId>& parmIds,
                     const Box& domain)
       { itsRep->getValues (values, nameIds, parmIds, domain); }
 

--- a/ParmDB/ParmDBBlob.h
+++ b/ParmDB/ParmDBBlob.h
@@ -69,13 +69,13 @@ namespace BBS {
 
     // Set the default step values.
     // It throws a "not implemented" exception.
-    virtual void setDefaultSteps (const vector<double>&);
+    virtual void setDefaultSteps (const std::vector<double>&);
 
     // Get the parameter values for the given parameters and domain.
     // It throws a "not implemented" exception.
-    virtual void getValues (vector<ParmValueSet>& values,
-                            const vector<uint>& nameIds,
-                            const vector<ParmId>& parmIds,
+    virtual void getValues (std::vector<ParmValueSet>& values,
+                            const std::vector<uint>& nameIds,
+                            const std::vector<ParmId>& parmIds,
                             const Box& domain);
 
     // Put the values for the given parameter name and id.

--- a/ParmDB/ParmDBCasa.h
+++ b/ParmDB/ParmDBCasa.h
@@ -70,13 +70,13 @@ namespace BBS {
     // </group>
 
     // Set the default step values.
-    virtual void setDefaultSteps (const vector<double>&);
+    virtual void setDefaultSteps (const std::vector<double>&);
 
     // Get the parameter values for the given parameters and domain.
     // The parmids form the indices in the result vector.
-    virtual void getValues (vector<ParmValueSet>& values,
-                            const vector<uint>& nameIds,
-                            const vector<ParmId>& parmIds,
+    virtual void getValues (std::vector<ParmValueSet>& values,
+                            const std::vector<uint>& nameIds,
+                            const std::vector<ParmId>& parmIds,
                             const Box& domain);
 
     // Put the values for the given parameter name and id.

--- a/ParmDB/ParmFacade.h
+++ b/ParmDB/ParmFacade.h
@@ -73,18 +73,18 @@ namespace DP3 { namespace BBS {
     // parameters in the table.
     // This is the minimum start value and maximum end value for all parameters.
     // An empty name pattern is the same as * (all parm names).
-    vector<double> getRange (const string& parmNamePattern = string()) const
+    std::vector<double> getRange (const string& parmNamePattern = string()) const
       { return itsRep->getRange (parmNamePattern); }
 
     // Get parameter names in the table matching the pattern.
     // An empty name pattern is the same as * (all parm names).
-    vector<string> getNames (const string& parmNamePattern = string(),
+    std::vector<string> getNames (const string& parmNamePattern = string(),
                              bool includeDefaults = false) const
     { return itsRep->getNames (parmNamePattern, includeDefaults); }
 
     // Get default parameter names in the table matching the pattern.
     // An empty name pattern is the same as * (all parm names).
-    vector<string> getDefNames (const string& parmNamePattern = string()) const
+    std::vector<string> getDefNames (const string& parmNamePattern = string()) const
       { return itsRep->getDefNames (parmNamePattern); }
 
     // Get default values of parameters in the table matching the pattern.
@@ -139,10 +139,10 @@ namespace DP3 { namespace BBS {
     // represents center/width or start/end.
     // The Record contains a map of parameter name to Array<double>.
     casacore::Record getValues (const string& parmNamePattern,
-                            const vector<double>& freqv1,
-                            const vector<double>& freqv2,
-                            const vector<double>& timev1,
-                            const vector<double>& timev2,
+                            const std::vector<double>& freqv1,
+                            const std::vector<double>& freqv2,
+                            const std::vector<double>& timev1,
+                            const std::vector<double>& timev2,
                             bool asStartEnd=true,
                             bool includeDefaults=false)
       { return itsRep->getValues (parmNamePattern, freqv1, freqv2,
@@ -209,11 +209,11 @@ namespace DP3 { namespace BBS {
     // </group>
 
     // Get the default step values for the frequency and time axis.
-    vector<double> getDefaultSteps() const
+    std::vector<double> getDefaultSteps() const
       { return itsRep->getDefaultSteps(); }
 
     // Set the default step values for the frequency and time axis.
-    void setDefaultSteps (const vector<double>& steps)
+    void setDefaultSteps (const std::vector<double>& steps)
       { itsRep->setDefaultSteps (steps); }
 
     // Add the values for the given parameter names and domain.

--- a/ParmDB/ParmFacadeLocal.h
+++ b/ParmDB/ParmFacadeLocal.h
@@ -71,16 +71,16 @@ namespace DP3 { namespace BBS {
     // parameters in the table.
     // This is the minimum start value and maximum end value for all parameters.
     // An empty name pattern is the same as * (all parm names).
-    virtual vector<double> getRange (const string& parmNamePattern) const;
+    virtual std::vector<double> getRange (const string& parmNamePattern) const;
 
     // Get parameter names in the table matching the pattern.
     // An empty name pattern is the same as * (all parm names).
-    virtual vector<string> getNames (const string& parmNamePattern,
+    virtual std::vector<string> getNames (const string& parmNamePattern,
                                      bool includeDefaults) const;
 
     // Get default parameter names matching the pattern.
     // An empty name pattern is the same as * (all parm names).
-    virtual vector<string> getDefNames (const string& parmNamePattern) const;
+    virtual std::vector<string> getDefNames (const string& parmNamePattern) const;
 
     // Get the default values of parameters matching the pattern.
     virtual casacore::Record getDefValues (const string& parmNamePattern) const;
@@ -106,10 +106,10 @@ namespace DP3 { namespace BBS {
     // represents center/width or start/end.
     // The Record contains a map of parameter name to Array<double>.
     virtual casacore::Record getValues (const string& parmNamePattern,
-                                    const vector<double>& freqv1,
-                                    const vector<double>& freqv2,
-                                    const vector<double>& timev1,
-                                    const vector<double>& timev2,
+                                    const std::vector<double>& freqv1,
+                                    const std::vector<double>& freqv2,
+                                    const std::vector<double>& timev1,
+                                    const std::vector<double>& timev2,
                                     bool asStartEnd,
                                     bool includeDefaults);
 
@@ -145,10 +145,10 @@ namespace DP3 { namespace BBS {
     // </group>
 
     // Get the default step values for the axes.
-    virtual vector<double> getDefaultSteps() const;
+    virtual std::vector<double> getDefaultSteps() const;
 
     // Set the default step values.
-    virtual void setDefaultSteps (const vector<double>&);
+    virtual void setDefaultSteps (const std::vector<double>&);
 
     // Add the values for the given parameter names and domain.
     virtual void addValues (const casacore::Record& rec);

--- a/ParmDB/ParmFacadeRep.h
+++ b/ParmDB/ParmFacadeRep.h
@@ -68,16 +68,16 @@ namespace DP3 { namespace BBS {
     // of the given parameters in the table.
     // This is the minimum start value and maximum end value for all parameters.
     // An empty name pattern is the same as * (all parm names).
-    virtual vector<double> getRange (const string& parmNamePattern) const = 0;
+    virtual std::vector<double> getRange (const string& parmNamePattern) const = 0;
 
     // Get parameter names in the table matching the pattern.
     // An empty name pattern is the same as * (all parm names).
-    virtual vector<string> getNames (const string& parmNamePattern,
+    virtual std::vector<string> getNames (const string& parmNamePattern,
                                      bool includeDefaults) const = 0;
 
     // Get default parameter names matching the pattern.
     // An empty name pattern is the same as * (all parm names).
-    virtual vector<string> getDefNames (const string& parmNamePattern) const = 0;
+    virtual std::vector<string> getDefNames (const string& parmNamePattern) const = 0;
 
     // Get the default values of parameters matching the pattern.
     virtual casacore::Record getDefValues (const string& parmNamePattern) const = 0;
@@ -106,10 +106,10 @@ namespace DP3 { namespace BBS {
     // represents center/width or start/end.
     // The Record contains a map of parameter name to Array<double>.
     virtual casacore::Record getValues (const string& parmNamePattern,
-                                    const vector<double>& freqv1,
-                                    const vector<double>& freqv2,
-                                    const vector<double>& timev1,
-                                    const vector<double>& timev2,
+                                    const std::vector<double>& freqv1,
+                                    const std::vector<double>& freqv2,
+                                    const std::vector<double>& timev1,
+                                    const std::vector<double>& timev2,
                                     bool asStartEnd,
                                     bool includeDefaults) = 0;
 
@@ -145,7 +145,7 @@ namespace DP3 { namespace BBS {
     virtual void clearTables() = 0;
 
     // Set the default step values.
-    virtual void setDefaultSteps (const vector<double>&) = 0;
+    virtual void setDefaultSteps (const std::vector<double>&) = 0;
 
     // Delete the records for the given parameters and domain.
     virtual void deleteValues (const string& parmNamePattern,
@@ -157,7 +157,7 @@ namespace DP3 { namespace BBS {
     // The ParmFacadeDistr functions throw an exception.
 
     // Get the default step values for the axes.
-    virtual vector<double> getDefaultSteps() const = 0;
+    virtual std::vector<double> getDefaultSteps() const = 0;
 
     // Add the values for the given parameter names and domain.
     // The name of each field in the record is the parameter name.

--- a/ParmDB/ParmSet.h
+++ b/ParmDB/ParmSet.h
@@ -82,14 +82,14 @@ namespace BBS {
     ParmId find (const string& name) const;
 
     // Get the ParmDBs used in the ParmSet.
-    const vector<ParmDB*> getDBs() const
+    const std::vector<ParmDB*> getDBs() const
       { return itsDBs; }
 
     // Get the values for the given work domain for all parameters that are
     // not part of the given vector.
     // It means that the vector gets extended for all parameters at the end
     // of itsParms.
-    void getValues (vector<ParmValueSet>&, const Box& workDomain) const;
+    void getValues (std::vector<ParmValueSet>&, const Box& workDomain) const;
 
     // Write the parm values for the given parmid.
     // For parms with a new name, ParmKey::itsNameId will get filled in.
@@ -149,8 +149,8 @@ namespace BBS {
     };
 
     //# Data members of ParmSet.
-    vector<ParmDB*> itsDBs;
-    vector<ParmKey> itsParms;
+    std::vector<ParmDB*> itsDBs;
+    std::vector<ParmKey> itsParms;
     std::map<std::string,int> itsNames;
   };
 

--- a/ParmDB/SourceDB.h
+++ b/ParmDB/SourceDB.h
@@ -77,10 +77,10 @@ namespace BBS {
     virtual void checkDuplicates() = 0;
 
     // Find non-unique patch names.
-    virtual vector<string> findDuplicatePatches() = 0;
+    virtual std::vector<string> findDuplicatePatches() = 0;
 
     // Find non-unique source names.
-    virtual vector<string> findDuplicateSources() = 0;
+    virtual std::vector<string> findDuplicateSources() = 0;
 
     // Test if the patch already exists.
     virtual bool patchExists (const string& patchName) = 0;
@@ -132,27 +132,27 @@ namespace BBS {
     // Get patch names in order of category and decreasing apparent flux.
     // category < 0 means all categories.
     // A brightness < 0 means no test on brightness.
-    virtual vector<string> getPatches (int category, const string& pattern,
+    virtual std::vector<string> getPatches (int category, const string& pattern,
                                        double minBrightness,
                                        double maxBrightness) = 0;
 
     // Get the info of selected patches (default all patches).
-    virtual vector<PatchInfo> getPatchInfo (int category,
+    virtual std::vector<PatchInfo> getPatchInfo (int category,
                                             const string& pattern,
                                             double minBrightness,
                                             double maxBrightness) = 0;
 
     // Get the sources belonging to the given patch.
-    virtual vector<SourceInfo> getPatchSources (const string& patchName) = 0;
+    virtual std::vector<SourceInfo> getPatchSources (const string& patchName) = 0;
 
     // Get all data of the sources belonging to the given patch.
-    virtual vector<SourceData> getPatchSourceData (const string& patchName) = 0;
+    virtual std::vector<SourceData> getPatchSourceData (const string& patchName) = 0;
 
     // Get the source type of the given source.
     virtual SourceInfo getSource (const string& sourceName) = 0;
 
     // Get the info of all sources matching the given (filename like) pattern.
-    virtual vector<SourceInfo> getSources (const string& pattern) = 0;
+    virtual std::vector<SourceInfo> getSources (const string& pattern) = 0;
 
     // Delete the sources records matching the given (filename like) pattern.
     virtual void deleteSources (const std::string& sourceNamePattern) = 0;
@@ -217,11 +217,11 @@ namespace BBS {
       { itsRep->checkDuplicates(); }
 
     // Find non-unique patch names.
-    vector<string> findDuplicatePatches() const
+    std::vector<string> findDuplicatePatches() const
       { return itsRep->findDuplicatePatches(); }
 
     // Find non-unique source names.
-    vector<string> findDuplicateSources() const
+    std::vector<string> findDuplicateSources() const
       { return itsRep->findDuplicateSources(); }
 
     // Test if the patch already exists.
@@ -283,7 +283,7 @@ namespace BBS {
     // Get patch names in order of category and decreasing apparent flux.
     // category < 0 means all categories.
     // A brightness < 0 means no test on brightness.
-    vector<string> getPatches (int category = -1,
+    std::vector<string> getPatches (int category = -1,
                                const string& pattern = string(),
                                double minBrightness = -1,
                                double maxBrightness = -1) const
@@ -291,7 +291,7 @@ namespace BBS {
                                    minBrightness, maxBrightness); }
 
     // Get the info of all patches (name, ra, dec).
-    vector<PatchInfo> getPatchInfo (int category = -1,
+    std::vector<PatchInfo> getPatchInfo (int category = -1,
                                     const string& pattern = string(),
                                     double minBrightness = -1,
                                     double maxBrightness = -1) const
@@ -299,11 +299,11 @@ namespace BBS {
                                      minBrightness, maxBrightness); }
 
     // Get the info of the sources belonging to the given patch.
-    vector<SourceInfo> getPatchSources (const string& patchName) const
+    std::vector<SourceInfo> getPatchSources (const string& patchName) const
       { return itsRep->getPatchSources (patchName); }
 
     // Get all data of the sources belonging to the given patch.
-    vector<SourceData> getPatchSourceData (const string& patchName) const
+    std::vector<SourceData> getPatchSourceData (const string& patchName) const
       { return itsRep->getPatchSourceData (patchName); }
 
     // Get the source info of the given source.
@@ -311,7 +311,7 @@ namespace BBS {
       { return itsRep->getSource (sourceName); }
 
     // Get the info of all sources matching the given (filename like) pattern.
-    vector<SourceInfo> getSources (const string& sourceNamePattern) const
+    std::vector<SourceInfo> getSources (const string& sourceNamePattern) const
       { return itsRep->getSources (sourceNamePattern); }
 
     // Delete the sources records matching the given (filename like) pattern.

--- a/ParmDB/SourceDBBlob.h
+++ b/ParmDB/SourceDBBlob.h
@@ -62,10 +62,10 @@ namespace BBS {
     virtual void checkDuplicates();
 
     // Find non-unique patch names.
-    virtual vector<string> findDuplicatePatches();
+    virtual std::vector<string> findDuplicatePatches();
 
     // Find non-unique source names.
-    virtual vector<string> findDuplicateSources();
+    virtual std::vector<string> findDuplicateSources();
 
     // Test if the patch already exists.
     virtual bool patchExists (const string& patchName);
@@ -117,27 +117,27 @@ namespace BBS {
     // Get patch names in order of category and decreasing apparent flux.
     // category < 0 means all categories.
     // A brightness < 0 means no test on brightness.
-    virtual vector<string> getPatches (int category, const string& pattern,
+    virtual std::vector<string> getPatches (int category, const string& pattern,
                                        double minBrightness,
                                        double maxBrightness);
 
     // Get the info of all patches (name, ra, dec).
-    virtual vector<PatchInfo> getPatchInfo (int category,
+    virtual std::vector<PatchInfo> getPatchInfo (int category,
                                             const string& pattern,
                                             double minBrightness,
                                             double maxBrightness);
 
     // Get the sources belonging to the given patch.
-    virtual vector<SourceInfo> getPatchSources (const string& patchName);
+    virtual std::vector<SourceInfo> getPatchSources (const string& patchName);
 
     // Get all data of the sources belonging to the given patch.
-    virtual vector<SourceData> getPatchSourceData (const string& patchName);
+    virtual std::vector<SourceData> getPatchSourceData (const string& patchName);
 
     // Get the source info of the given source.
     virtual SourceInfo getSource (const string& sourceName);
 
     // Get the info of all sources matching the given (filename like) pattern.
-    virtual vector<SourceInfo> getSources (const string& pattern);
+    virtual std::vector<SourceInfo> getSources (const string& pattern);
 
     // Delete the sources records matching the given (filename like) pattern.
     // This is not possible yet.
@@ -169,7 +169,7 @@ namespace BBS {
     bool  itsCanWrite;
     int64_t itsEndPos;
     std::map<std::string, PatchInfo>            itsPatches;
-    std::map<std::string, vector<SourceData> >  itsSources;   //# sources per patch
+    std::map<std::string, std::vector<SourceData> >  itsSources;   //# sources per patch
   };
 
   // @}

--- a/ParmDB/SourceDBCasa.h
+++ b/ParmDB/SourceDBCasa.h
@@ -63,10 +63,10 @@ namespace BBS {
     virtual void checkDuplicates();
 
     // Find non-unique patch names.
-    virtual vector<string> findDuplicatePatches();
+    virtual std::vector<string> findDuplicatePatches();
 
     // Find non-unique source names.
-    virtual vector<string> findDuplicateSources();
+    virtual std::vector<string> findDuplicateSources();
 
     // Test if the patch already exists.
     virtual bool patchExists (const string& patchName);
@@ -118,27 +118,27 @@ namespace BBS {
     // Get patch names in order of category and decreasing apparent flux.
     // category < 0 means all categories.
     // A brightness < 0 means no test on brightness.
-    virtual vector<string> getPatches (int category, const string& pattern,
+    virtual std::vector<string> getPatches (int category, const string& pattern,
                                        double minBrightness,
                                        double maxBrightness);
 
     // Get the info of all patches (name, ra, dec).
-    virtual vector<PatchInfo> getPatchInfo (int category,
+    virtual std::vector<PatchInfo> getPatchInfo (int category,
                                             const string& pattern,
                                             double minBrightness,
                                             double maxBrightness);
 
     // Get the sources belonging to the given patch.
-    virtual vector<SourceInfo> getPatchSources (const string& patchName);
+    virtual std::vector<SourceInfo> getPatchSources (const string& patchName);
 
     // Get all data of the sources belonging to the given patch.
-    virtual vector<SourceData> getPatchSourceData (const string& patchName);
+    virtual std::vector<SourceData> getPatchSourceData (const string& patchName);
 
     // Get the source info of the given source.
     virtual SourceInfo getSource (const string& sourceName);
 
     // Get the info of all sources matching the given (filename like) pattern.
-    virtual vector<SourceInfo> getSources (const string& pattern);
+    virtual std::vector<SourceInfo> getSources (const string& pattern);
 
     // Delete the sources records matching the given (filename like) pattern.
     virtual void deleteSources (const std::string& sourceNamePattern);
@@ -171,7 +171,7 @@ namespace BBS {
                      double ra, double dec, uint rownr);
 
     // Find the duplicate patches or sources.
-    vector<string> findDuplicates (casacore::Table& table,
+    std::vector<string> findDuplicates (casacore::Table& table,
                                    const string& columnName);
 
     // Fill the patch and source set object from the tables.

--- a/ParmDB/SourceData.h
+++ b/ParmDB/SourceData.h
@@ -89,7 +89,7 @@ namespace BBS {
       { return itsPolFrac; }
     double getRotationMeasure() const
       { return itsRM; }
-    const vector<double>& getSpectralTerms() const
+    const std::vector<double>& getSpectralTerms() const
       { return itsSpTerms; }
 
     // Set the various source parameters.
@@ -121,7 +121,7 @@ namespace BBS {
       { itsPolFrac =  polarizedFraction; }
     void setRotationMeasure (double potationMeasure)
       { itsRM = potationMeasure; }
-    void setSpectralTerms (const vector<double>& spectralTerms)
+    void setSpectralTerms (const std::vector<double>& spectralTerms)
       { itsSpTerms = spectralTerms; }
 
     // Set the parameters from a ParmMap object.
@@ -165,7 +165,7 @@ namespace BBS {
     double         itsPolAngle;
     double         itsPolFrac;
     double         itsRM;
-    vector<double> itsSpTerms;
+    std::vector<double> itsSpTerms;
   };
 
   // @}


### PR DESCRIPTION
Due to removal of 'using namespace std' from header of casacore, using just 'vector' no longer works in DP3 header files. This commit adds std:: to all those usages.