### PR TITLE
Replace missing solutions by average gain

### DIFF
--- a/DDECal/MultiDirSolver.h
+++ b/DDECal/MultiDirSolver.h
@@ -119,8 +119,16 @@ private:
 
   bool detectStall(size_t iteration, const std::vector<double>& stepMagnitudes) const;
                 
-  void makeSolutionsFinite(std::vector<std::vector<DComplex> >& solutions, size_t perPol) const;
-                
+  static void makeSolutionsFinite1pol(std::vector<std::vector<DComplex> >& solutions);
+  
+  static void makeSolutionsFinite4pol(std::vector<std::vector<DComplex> >& solutions);
+  
+  template<typename T>
+  static bool isfinite(const std::complex<T>& val)
+  {
+    return std::isfinite(val.real()) && std::isfinite(val.imag());
+  }
+  
   /**
    * Assign the solutions in nextSolutions to the solutions.
    * @returns whether the solutions have converged. Appends the current step magnitude to step_magnitudes


### PR DESCRIPTION
During solution propagation, instead of replacing missing (nan) solutions by unity, this commit will replace missing solutions by the average absolute gain. I decided to use average absolute instead of normal (complex) average, because otherwise this might result in near-zero result when the phase changes a lot over stations. This is related to #81.

I've tested it on one of Francesco's sets, showing that i) it is correctly implemented and ii) it solves #81 in that particular case, but it's not yet clear whether #81 is solved in its entirely.