### PR TITLE
Reuse threads in GainCal's parallel for

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(DP3)
 
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/CMake)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++11 -O3 -march=native")
 
 find_package(HDF5 COMPONENTS C CXX REQUIRED)
 add_definitions(${HDF5_DEFINITIONS})

--- a/Common/Barrier.h
+++ b/Common/Barrier.h
@@ -8,12 +8,8 @@
 namespace DP3 {
 	
 	/**
-	 * Simple barrier class.
-	 * 
 	 * This class is unfortunately necessary because boost::barrier had a 
 	 * bug in completion functions, and std::barrier is still experimental.
-	 * 
-	 * It implements a barrier similar to boost::barrier.
 	 */
 	class Barrier
 	{
@@ -24,7 +20,7 @@ namespace DP3 {
 		 * @param completionFunction void function that is called when all threads have
 		 * arrived, just before the threads are released.
 		 */
-		Barrier(size_t n, std::function<void()> completionFunction) : _n(n), _count(_n), _completionFunction(completionFunction)
+		Barrier(size_t n, std::function<void()> completionFunction) : _n(n), _count(_n), _cycle(0), _completionFunction(completionFunction)
 		{
 		}
 		
@@ -37,12 +33,14 @@ namespace DP3 {
 			--_count;
 			if(_count == 0)
 			{
+				++_cycle;
 				_count = _n;
 				_completionFunction();
 				_condition.notify_all();
 			}
 			else {
-				while(_count != _n)
+				size_t cycle = _cycle;
+				while(cycle == _cycle) 
 					_condition.wait(lock);
 			}
 		}
@@ -50,7 +48,7 @@ namespace DP3 {
 	private:
 		std::mutex _mutex;
 		std::condition_variable _condition;
-		size_t _n, _count;
+		size_t _n, _count, _cycle;
 		std::function<void()> _completionFunction;
 	};
 }

--- a/Common/Barrier.h
+++ b/Common/Barrier.h
@@ -9,7 +9,8 @@ namespace DP3 {
   
   /**
   * This class is unfortunately necessary because boost::barrier had a 
-  * bug in completion functions, and std::barrier is still experimental.
+  * bug in completion functions ( https://svn.boost.org/trac10/ticket/13561 ),
+  * and std::barrier is still experimental.
   */
   class Barrier
   {

--- a/Common/Barrier.h
+++ b/Common/Barrier.h
@@ -1,0 +1,58 @@
+#ifndef BARRIER_H
+#define BARRIER_H
+
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+
+namespace DP3 {
+	
+	/**
+	 * Simple barrier class.
+	 * 
+	 * This class is unfortunately necessary because boost::barrier had a 
+	 * bug in completion functions, and std::barrier is still experimental.
+	 * 
+	 * It implements a barrier similar to boost::barrier.
+	 */
+	class Barrier
+	{
+	public:
+		/**
+		 * Construct barrier for n threads with the given completion function.
+		 * @param n Number of threads to wait for
+		 * @param completionFunction void function that is called when all threads have
+		 * arrived, just before the threads are released.
+		 */
+		Barrier(size_t n, std::function<void()> completionFunction) : _n(n), _count(_n), _completionFunction(completionFunction)
+		{
+		}
+		
+		/**
+		 * Wait until all threads are waiting for the barrier.
+		 */
+		void wait()
+		{
+			std::unique_lock<std::mutex> lock(_mutex);
+			--_count;
+			if(_count == 0)
+			{
+				_count = _n;
+				_completionFunction();
+				_condition.notify_all();
+			}
+			else {
+				while(_count != _n)
+					_condition.wait(lock);
+			}
+		}
+		
+	private:
+		std::mutex _mutex;
+		std::condition_variable _condition;
+		size_t _n, _count;
+		std::function<void()> _completionFunction;
+	};
+}
+
+#endif

--- a/Common/Barrier.h
+++ b/Common/Barrier.h
@@ -6,51 +6,62 @@
 #include <mutex>
 
 namespace DP3 {
-	
-	/**
-	 * This class is unfortunately necessary because boost::barrier had a 
-	 * bug in completion functions, and std::barrier is still experimental.
-	 */
-	class Barrier
-	{
-	public:
-		/**
-		 * Construct barrier for n threads with the given completion function.
-		 * @param n Number of threads to wait for
-		 * @param completionFunction void function that is called when all threads have
-		 * arrived, just before the threads are released.
-		 */
-		Barrier(size_t n, std::function<void()> completionFunction) : _n(n), _count(_n), _cycle(0), _completionFunction(completionFunction)
-		{
-		}
-		
-		/**
-		 * Wait until all threads are waiting for the barrier.
-		 */
-		void wait()
-		{
-			std::unique_lock<std::mutex> lock(_mutex);
-			--_count;
-			if(_count == 0)
-			{
-				++_cycle;
-				_count = _n;
-				_completionFunction();
-				_condition.notify_all();
-			}
-			else {
-				size_t cycle = _cycle;
-				while(cycle == _cycle) 
-					_condition.wait(lock);
-			}
-		}
-		
-	private:
-		std::mutex _mutex;
-		std::condition_variable _condition;
-		size_t _n, _count, _cycle;
-		std::function<void()> _completionFunction;
-	};
+  
+  /**
+  * This class is unfortunately necessary because boost::barrier had a 
+  * bug in completion functions, and std::barrier is still experimental.
+  */
+  class Barrier
+  {
+  public:
+    /**
+    * Construct barrier for n threads with the given completion function.
+    * @param n Number of threads to wait for
+    * @param completionFunction void function that is called when all threads have
+    * arrived, just before the threads are released.
+    */
+    Barrier(size_t n, std::function<void()> completionFunction) : _n(n), _count(_n), _cycle(0), _completionFunction(completionFunction)
+    {
+    }
+    
+    Barrier& operator=(Barrier&& rhs)
+    {
+      // count could be checked for != _n to assert no threads
+      // are waiting, but I leave this the responsibility of the caller.
+      _n = rhs._n;
+      _count = _n;
+      _cycle = 0;
+      _completionFunction = rhs._completionFunction;
+      return *this;
+    }
+    
+    /**
+    * Wait until all threads are waiting for the barrier.
+    */
+    void wait()
+    {
+      std::unique_lock<std::mutex> lock(_mutex);
+      --_count;
+      if(_count == 0)
+      {
+        ++_cycle;
+        _count = _n;
+        _completionFunction();
+        _condition.notify_all();
+      }
+      else {
+        size_t cycle = _cycle;
+        while(cycle == _cycle) 
+          _condition.wait(lock);
+      }
+    }
+    
+  private:
+    std::mutex _mutex;
+    std::condition_variable _condition;
+    size_t _n, _count, _cycle;
+    std::function<void()> _completionFunction;
+  };
 }
 
 #endif

--- a/Common/ParallelFor.h
+++ b/Common/ParallelFor.h
@@ -53,7 +53,7 @@ namespace DP3 {
     {
       if(end == start+1)
       {
-        _loopFunction(start, 0);
+        function(start, 0);
       }
       else {
         if(_threads.empty())

--- a/Common/ParallelFor.h
+++ b/Common/ParallelFor.h
@@ -21,46 +21,72 @@ namespace DP3 {
     ParallelFor(size_t nThreads) :
       _nThreads(nThreads), _barrier(nThreads, [&](){ _hasTasks=false; } ), _stop(false), _hasTasks(false)
     {
-      startThreads();
     }
     
     ~ParallelFor()
     {
       std::unique_lock<std::mutex> lock(_mutex);
-      _stop = true;
-      _hasTasks = true;
-      _conditionChanged.notify_all();
-      lock.unlock();
-      for(std::thread& thr : _threads)
-        thr.join();
+      if(!_threads.empty())
+      {
+        _stop = true;
+        _hasTasks = true;
+        _conditionChanged.notify_all();
+        lock.unlock();
+        for(std::thread& thr : _threads)
+          thr.join();
+      }
     }
 
-  /**
-   * Iteratively call a function in parallel.
-   * 
-   * The function is expected to accept two size_t parameters, the loop
-   * index and the thread id, e.g.:
-   *   void loopFunction(size_t iteration, size_t threadID);
-   * It is called (end-start) times.
-   * 
-   * This function is very similar to ThreadPool::For(), but does not
-   * support recursion. For non-recursive loop, this function will be
-   * faster.
-   */
+    /**
+     * Iteratively call a function in parallel.
+     * 
+     * The function is expected to accept two size_t parameters, the loop
+     * index and the thread id, e.g.:
+     *   void loopFunction(size_t iteration, size_t threadID);
+     * It is called (end-start) times.
+     * 
+     * This function is very similar to ThreadPool::For(), but does not
+     * support recursion. For non-recursive loop, this function will be
+     * faster.
+     */
     void Run(Iter start, Iter end, std::function<void(size_t, size_t)> function)
     {
-      std::unique_lock<std::mutex> lock(_mutex);
-      _current = start;
-      _end = end;
-      _loopFunction = std::move(function);
-      _hasTasks = true;
-      _conditionChanged.notify_all();
-      lock.unlock();
-      loop(0);
-      _barrier.wait();
+      if(end == start+1)
+      {
+        _loopFunction(start, 0);
+      }
+      else {
+        if(_threads.empty())
+          startThreads();
+        std::unique_lock<std::mutex> lock(_mutex);
+        _current = start;
+        _end = end;
+        _loopFunction = std::move(function);
+        _hasTasks = true;
+        _conditionChanged.notify_all();
+        lock.unlock();
+        loop(0);
+        _barrier.wait();
+      }
     }
     
     size_t NThreads() const { return _nThreads; }
+    
+    /**
+     * This method is only allowed to be called before Run() is
+     * called.
+     */
+    void SetNThreads(size_t nThreads)
+    {
+      if(_threads.empty())
+      {
+        _nThreads = nThreads;
+        _barrier = Barrier(nThreads, [&](){ _hasTasks=false; });
+      }
+      else {
+        throw std::runtime_error("Can not set NThreads after calling Run()");
+      }
+    }
     
   private:
     ParallelFor(const ParallelFor&) = delete;

--- a/DPPP/GainCal.cc
+++ b/DPPP/GainCal.cc
@@ -634,9 +634,9 @@ namespace DP3 {
                                   info().antennaUsed().size(), 0);
 
       vector<GainCalAlgorithm::Status> converged(itsNFreqCells,GainCalAlgorithm::NOTCONVERGED);
+      ParallelFor<size_t> loop(getInfo().nThreads());
       for (;iter<itsMaxIter;++iter) {
         bool allConverged=true;
-        ParallelFor<size_t> loop(getInfo().nThreads());
         loop.Run(0, itsNFreqCells, [&](size_t freqCell, size_t /*thread*/) {
           // Do another step when stalled and not all converged
           if (converged[freqCell]!=GainCalAlgorithm::CONVERGED)

--- a/DPPP/GainCal.cc
+++ b/DPPP/GainCal.cc
@@ -41,6 +41,7 @@
 #include "../Common/ParallelFor.h"
 #include "../Common/ParameterSet.h"
 #include "../Common/StringUtil.h"
+#include "../Common/ThreadPool.h"
 
 #include <fstream>
 #include <ctime>
@@ -203,6 +204,11 @@ namespace DP3 {
       info() = infoIn;
       info().setNeedVisData();
 
+      // By giving a thread pool to the predicter, the threads are
+      // sustained.
+      itsThreadPool.reset(new ThreadPool(info().nThreads()));
+      itsPredictStep->setThreadData(*itsThreadPool, itsMeasuresMutex);
+        
       itsUVWFlagStep.updateInfo(infoIn);
 
       if (itsUseModelColumn) {

--- a/DPPP/GainCal.h
+++ b/DPPP/GainCal.h
@@ -178,6 +178,8 @@ namespace DP3 {
       ResultStep::ShPtr itsDataResultStep; // Result step for data after UV-flagging
 
       std::unique_ptr<Predict> itsPredictStep;
+      std::unique_ptr<class ThreadPool> itsThreadPool;
+      std::mutex itsMeasuresMutex;
 #ifdef HAVE_LOFAR_BEAM
       ApplyBeam         itsApplyBeamStep; // Beam step for applying beam to modelcol
 #endif

--- a/DPPP/GainCal.h
+++ b/DPPP/GainCal.h
@@ -42,6 +42,8 @@
 #include "../ParmDB/ParmFacade.h"
 #include "../ParmDB/ParmSet.h"
 
+#include "../Common/ParallelFor.h"
+
 #ifdef HAVE_LOFAR_BEAM
 #include <StationResponse/Station.h>
 #include <StationResponse/Types.h>
@@ -178,6 +180,7 @@ namespace DP3 {
       ResultStep::ShPtr itsDataResultStep; // Result step for data after UV-flagging
 
       std::unique_ptr<Predict> itsPredictStep;
+      ParallelFor<size_t> itsParallelFor;
       std::unique_ptr<class ThreadPool> itsThreadPool;
       std::mutex itsMeasuresMutex;
 #ifdef HAVE_LOFAR_BEAM

--- a/DPPP/Predict.cc
+++ b/DPPP/Predict.cc
@@ -381,13 +381,12 @@ namespace DP3 {
       });
 #ifdef HAVE_LOFAR_BEAM
       // Apply beam to the last patch
-      for(size_t thread=0; thread!=pool->NThreads(); ++thread)
-      {
+      pool->For(0, pool->NThreads(), [&](size_t thread, size_t) {
         if (itsApplyBeam && curPatches[thread]!=nullptr) {
           addBeamToData (curPatches[thread], time, refdir, tiledir, thread, nSamples,
             itsModelVisPatch[thread].data());
         }
-      }
+      });
 #endif
 
       // Add all thread model data to one buffer


### PR DESCRIPTION
I noticed that GainCal is slower than it used to be. I'm not sure why, but a lot of threads are restarted
during the parallel for structures. This commit keeps the threads running between iterations.

This required a barrier. Unfortunately, the barrier in boost is buggy and the barrier in std requires
c++20 which we probably want to avoid, so I implemented a very simple one myself.