### PR TITLE
Remove dependency on Boost signals 1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ find_package(Threads REQUIRED)
 
 #Prevent accidentally finding old BoostConfig.cmake file from casapy
 set(Boost_NO_BOOST_CMAKE ON)
-find_package(Boost COMPONENTS date_time filesystem python signals system REQUIRED)
+find_package(Boost COMPONENTS date_time filesystem python system REQUIRED)
 include_directories(${BOOST_INCLUDE_DIR})
 
 find_path(LOFAR_STATION_RESPONSE_DIR NAMES StationResponse/Station.h)


### PR DESCRIPTION
New Boost version no longer provide Boost signals version 1. It has been replaced
by version 2, which is part of the Boost core library and no longer requires an
explicit find_package parameter.