### PR TITLE
Do not set 'readVisData' back to false

### DIFF
--- a/DPPP/MSReader.cc
+++ b/DPPP/MSReader.cc
@@ -223,7 +223,7 @@ namespace DP3 {
 
     void MSReader::setReadVisData (bool readVisData)
     {
-      itsReadVisData = readVisData;
+      itsReadVisData = (itsReadVisData || readVisData);
     }
 
     bool MSReader::process (const DPBuffer&)

--- a/DPPP/MSReader.h
+++ b/DPPP/MSReader.h
@@ -193,7 +193,8 @@ namespace DP3 {
                                  const casacore::Vector<casacore::String>& antNames);
 #endif
       
-      // Tell if the visibility data are to be read.
+      // Tell if the visibility data are to be read. If set to true once,
+      // this will stay true.
       virtual void setReadVisData (bool readVisData);
 
       // Get the main MS table.


### PR DESCRIPTION
An MSWriter followed by an MSUpdater could have the effect of the MSUpdater telling the MSReader that it doesn't need to read the visibilities, even though the MSWriter had told it before that it did.