### PR TITLE
Fix antenna constraint when some antennas are unsolvable

### DIFF
--- a/DDECal/Constraint.cc
+++ b/DDECal/Constraint.cc
@@ -56,7 +56,7 @@ std::vector<Constraint::Result> AntennaConstraint::Apply(
     {
       setSolutions.assign(nSols, 0.0);
       setSolutionCounts.assign(nSols, 0);
-      // Calculate the sum of solutions over the core stations
+      // Calculate the sum of solutions over the set of stations
       for(size_t antennaIndex : antennaSet)
       {
         size_t startIndex = antennaIndex * nSols;

--- a/DDECal/Constraint.h
+++ b/DDECal/Constraint.h
@@ -97,6 +97,11 @@ public:
 
 protected:
   size_t _nAntennas, _nDirections, _nChannelBlocks, _nThreads;
+  
+  static bool isfinite(const dcomplex& value)
+  {
+    return std::isfinite(value.real()) && std::isfinite(value.imag());
+  }
 };
 
 /**

--- a/DDECal/RotationAndDiagonalConstraint.cc
+++ b/DDECal/RotationAndDiagonalConstraint.cc
@@ -82,11 +82,13 @@ vector<Constraint::Result> RotationAndDiagonalConstraint::Apply(
       a = data[0]*cos(angle) - data[1]*sin(angle);
       b = data[3]*cos(angle) + data[2]*sin(angle);
 
-      if (isfinite(abs(a))) {
-        amean += abs(a);
+      double absa = abs(a);
+      if (isfinite(absa)) {
+        amean += absa;
       }
-      if (isfinite(abs(b))) {
-        bmean += abs(b);
+      double absb = abs(b);
+      if (isfinite(absb)) {
+        bmean += absb;
       }
     }
     amean /= _nAntennas;

--- a/DDECal/SmoothnessConstraint.cc
+++ b/DDECal/SmoothnessConstraint.cc
@@ -37,8 +37,7 @@ std::vector<Constraint::Result> SmoothnessConstraint::Apply(
       for(size_t ch=0; ch!=_nChannelBlocks; ++ch)
       {
         // Flag channels where calibration yielded inf or nan
-        if(std::isfinite(solutions[ch][solutionIndex].real()) &&
-          std::isfinite(solutions[ch][solutionIndex].imag()))
+        if(isfinite(solutions[ch][solutionIndex].real()))
         {
           _fitData[thread].data[ch] = solutions[ch][solutionIndex];
           _fitData[thread].weight[ch] = _weights[antIndex*_nChannelBlocks + ch];

--- a/DDECal/SmoothnessConstraint.cc
+++ b/DDECal/SmoothnessConstraint.cc
@@ -37,7 +37,7 @@ std::vector<Constraint::Result> SmoothnessConstraint::Apply(
       for(size_t ch=0; ch!=_nChannelBlocks; ++ch)
       {
         // Flag channels where calibration yielded inf or nan
-        if(isfinite(solutions[ch][solutionIndex].real()))
+        if(isfinite(solutions[ch][solutionIndex]))
         {
           _fitData[thread].data[ch] = solutions[ch][solutionIndex];
           _fitData[thread].weight[ch] = _weights[antIndex*_nChannelBlocks + ch];

--- a/DDECal/TECConstraint.cc
+++ b/DDECal/TECConstraint.cc
@@ -114,8 +114,7 @@ std::vector<Constraint::Result> TECConstraint::Apply(
     // Flag channels where calibration yielded inf or nan
     double weightSum = 0.0;
     for(size_t ch=0; ch!=_nChannelBlocks; ++ch) {
-      if(std::isfinite(solutions[ch][solutionIndex].real()) &&
-        std::isfinite(solutions[ch][solutionIndex].imag()))
+      if(isfinite(solutions[ch][solutionIndex]))
       {
         _phaseFitters[thread].PhaseData()[ch] = std::arg(solutions[ch][solutionIndex]);
         _phaseFitters[thread].WeightData()[ch] = _weights[antennaIndex*_nChannelBlocks + ch];
@@ -170,8 +169,7 @@ std::vector<Constraint::Result> ApproximateTECConstraint::Apply(
       
       // Flag channels where calibration yielded inf or nan
       for(size_t ch=0; ch!=_nChannelBlocks; ++ch) {
-        if(std::isfinite(solutions[ch][solutionIndex].real()) &&
-          std::isfinite(solutions[ch][solutionIndex].imag()))
+        if(isfinite(solutions[ch][solutionIndex]))
         {
           data[ch] = std::arg(solutions[ch][solutionIndex]);
           weights[ch] = _weights[antennaIndex*_nChannelBlocks + ch];


### PR DESCRIPTION
Occurs e.g. when some antennas in the set of constrained antennas are completely flagged. Fixes #147.

Also cleaned isfinite calls a bit.