### PR TITLE
Replace asserts with throw std::runtime_error when appropriate

### DIFF
--- a/Common/BaselineSelect.cc
+++ b/Common/BaselineSelect.cc
@@ -38,8 +38,6 @@
 #include <casacore/casa/Arrays/Matrix.h>
 #include <casacore/casa/Arrays/Vector.h>
 
-#include <cassert>
-
 using namespace casacore;
 
 namespace DP3 {
@@ -81,7 +79,8 @@ namespace DP3 {
                                               const string& baselineSelection,
                                               std::ostream& os)
   {
-    assert (names.size() == pos.size());
+    if (names.size() != pos.size())
+      throw std::invalid_argument("Name and position arrays are of different size");
     // Create a temporary MSAntenna table in memory for parsing purposes.
     SetupNewTable antNew(String(), MSAntenna::requiredTableDesc(),
                          Table::New);

--- a/Common/NodeDesc.cc
+++ b/Common/NodeDesc.cc
@@ -53,10 +53,13 @@ namespace DP3 { namespace CEP {
     }
     itsMounts  = parset.getStringVector ("NodeMountPoints", true);
     itsFileSys = parset.getStringVector ("NodeFileSys", itsMounts, true);
-    assert (itsFileSys.size() == itsMounts.size());
+    if (itsFileSys.size() != itsMounts.size())
+      throw std::runtime_error("NodeMountPoints and NodeFileSys should have the same size");
     for (unsigned int i=0; i<itsMounts.size(); ++i) {
-      assert (itsFileSys[i].size() > 0);
-      assert (itsMounts[i].size() > 0  &&  itsMounts[i][0] == '/');
+      if (itsFileSys[i].size() == 0)
+        throw std::runtime_error("NodeFileSys elements can't be empty");
+      if (itsMounts[i].size() == 0  ||  itsMounts[i][0] != '/')
+        throw std::runtime_error("NodeMountPoints elements can't be empty and need to start with /");
     }
   }
 

--- a/Common/Timer.cc
+++ b/Common/Timer.cc
@@ -20,7 +20,6 @@
 //#
 //# $Id: Timer.cc 31468 2015-04-13 23:26:52Z amesfoort $
 
-#include <cassert>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
@@ -42,8 +41,8 @@ double NSTimer::CPU_speed_in_MHz = NSTimer::get_CPU_speed_in_MHz();
 double NSTimer::get_CPU_speed_in_MHz()
 {
     // first a few sanity checks
-    assert(sizeof(int) == 4);
-    assert(sizeof(long long) == 8);
+    static_assert(sizeof(int) == 4, "sizeof(int) == 4 is required");
+    static_assert(sizeof(long long) == 8, "sizeof(long long) == 8 is required");
 
 #if (defined __linux__ || defined __blrts__) && \
     (defined __i386__ || defined __x86_64__ || defined __ia64__ || defined __PPC__) && \

--- a/Common/VdsPartDesc.cc
+++ b/Common/VdsPartDesc.cc
@@ -54,14 +54,17 @@ namespace DP3 { namespace CEP {
     string timeStr;
     Quantity q;
     timeStr = parset.getString ("StartTime");
-    assert (MVTime::read (q, timeStr, true));
+    if (!MVTime::read (q, timeStr, true))
+      throw std::runtime_error("Could not parse StartTime");
     itsStartTime = q.getValue ("s");
     timeStr = parset.getString ("EndTime");
-    assert (MVTime::read (q, timeStr, true));
+    if (!MVTime::read (q, timeStr, true))
+      throw std::runtime_error("Could not parse EndTime");
     itsEndTime = q.getValue ("s");
     itsStartTimes = parset.getDoubleVector ("StartTimesDiff", vector<double>());
     itsEndTimes   = parset.getDoubleVector ("EndTimesDiff",   vector<double>());
-    assert (itsStartTimes.size() == itsEndTimes.size());
+    if (itsStartTimes.size() != itsEndTimes.size())
+      throw std::runtime_error("StartTimeDiff and EndTimeDiff arrays had different sizes");
     double diff = itsStartTime;
     for (unsigned int i=0; i<itsStartTimes.size(); ++i) {
       itsStartTimes[i] += diff;
@@ -145,7 +148,6 @@ namespace DP3 { namespace CEP {
                               const vector<double>& startTimes,
                               const vector<double>& endTimes)
   {
-    assert (itsStartTimes.size() == itsEndTimes.size());
     itsStartTime  = startTime;
     itsEndTime    = endTime;
     itsStepTime   = stepTime;
@@ -165,7 +167,7 @@ namespace DP3 { namespace CEP {
   }
 
   void VdsPartDesc::addBand (int nchan, const vector<double>& startFreq,
-			     const vector<double>& endFreq)
+    const vector<double>& endFreq)
   {
     assert (startFreq.size() == endFreq.size());
     assert (int(startFreq.size())==nchan || startFreq.size() == 1);

--- a/DDECal/RotationAndDiagonalConstraint.cc
+++ b/DDECal/RotationAndDiagonalConstraint.cc
@@ -1,7 +1,6 @@
 #include "RotationAndDiagonalConstraint.h"
 #include "RotationConstraint.h"
 
-#include <cassert>
 #include <cmath>
 
 using namespace std;
@@ -13,8 +12,9 @@ void RotationAndDiagonalConstraint::InitializeDimensions(size_t nAntennas,
                                                          size_t nChannelBlocks) {
   Constraint::InitializeDimensions(nAntennas, nDirections, nChannelBlocks);
 
-  assert(_nDirections == 1); // TODO directions!
-
+  if(_nDirections != 1) // TODO directions!
+    throw std::runtime_error("RotationAndDiagonalConstraint can't handle multiple directions yet");
+  
   _res.resize(3);
   _res[0].vals.resize(_nAntennas*_nChannelBlocks);
   _res[0].weights.resize(_nAntennas*_nChannelBlocks);

--- a/DDECal/RotationConstraint.cc
+++ b/DDECal/RotationConstraint.cc
@@ -12,7 +12,8 @@ namespace DP3 {
                                                 size_t nChannelBlocks) {
   Constraint::InitializeDimensions(nAntennas, nDirections, nChannelBlocks);
 
-  assert(_nDirections == 1); // TODO directions!
+  if(_nDirections != 1) // TODO directions!
+    throw std::runtime_error("RotationConstraint can't handle multiple directions yet");
 
   _res.resize(1);
   _res[0].vals.resize(_nAntennas*_nChannelBlocks);

--- a/DPPP/ApplyBeam.cc
+++ b/DPPP/ApplyBeam.cc
@@ -75,7 +75,6 @@ namespace DP3 {
         itsInvert=parset.getBool(prefix + "invert", true);
       }
       string mode=boost::to_lower_copy(parset.getString(prefix + "beammode","default"));
-      assert (mode=="default" || mode=="array_factor" || mode=="element");
       if (mode=="default") {
         itsMode=FullBeamCorrection;
       } else if (mode=="array_factor") {

--- a/DPPP/Averager.cc
+++ b/DPPP/Averager.cc
@@ -31,7 +31,6 @@
 
 #include <casacore/casa/Arrays/ArrayMath.h>
 
-#include <cassert>
 #include <iostream>
 #include <iomanip>
 
@@ -207,7 +206,8 @@ namespace DP3 {
         // Not the first time.
         // For now we assume that all timeslots have the same nr of baselines,
         // so check if the buffer sizes are the same.
-        assert (itsBuf.getData().shape() == buf.getData().shape());
+        if (itsBuf.getData().shape() != buf.getData().shape())
+          throw std::runtime_error("Inconsistent buffer sizes in Averager, possibly because of inconsistent nr of baselines in timeslots");
         itsBufTmp.referenceFilled (buf);
         itsBuf.getUVW() += itsInput->fetchUVW (buf, itsBufTmp, itsTimer);
         copyFullResFlags (itsInput->fetchFullResFlags (buf, itsBufTmp, itsTimer),

--- a/DPPP/BaselineSelection.cc
+++ b/DPPP/BaselineSelection.cc
@@ -32,8 +32,6 @@
 #include "../Common/ParameterValue.h"
 #include "../Common/StreamUtil.h"
 
-#include <cassert>
-
 using namespace casacore;
 using namespace std;
 
@@ -140,7 +138,8 @@ namespace DP3 {
       } else {
         // Specified in casacore's MSSelection format.
         string msName = info.msName();
-        assert (! msName.empty());
+        if (msName.empty())
+          throw std::runtime_error("Empty measurement set name");
         std::ostringstream os;
         Matrix<bool> sel(BaselineSelect::convert (msName, itsStrBL, os));
         // Show possible messages about unknown stations.

--- a/DPPP/DPInfo.cc
+++ b/DPPP/DPInfo.cc
@@ -31,8 +31,6 @@
 #include <casacore/casa/Arrays/ArrayIO.h>
 #include <casacore/casa/BasicSL/STLIO.h>
 
-#include <cassert>
-
 using namespace casacore;
 using namespace std;
 
@@ -122,9 +120,11 @@ namespace DP3 {
                       const Vector<Int>& ant1,
                       const Vector<Int>& ant2)
     {
-      assert (antNames.size() == antDiam.size()  &&
-              antNames.size() == antPos.size());
-      assert (ant1.size() == ant2.size());
+      if (antNames.size() != antDiam.size()  ||
+          antNames.size() != antPos.size())
+        throw std::invalid_argument("The name, diameter and position arrays are not of the same size");
+      if (ant1.size() != ant2.size())
+        throw std::invalid_argument("The ant1 and ant2 arrays are not of the same size");
       itsAntNames.reference (antNames);
       itsAntDiam.reference (antDiam);
       itsAntPos = antPos;
@@ -140,8 +140,9 @@ namespace DP3 {
       itsAntMap.resize (itsAntNames.size());
       std::fill (itsAntMap.begin(), itsAntMap.end(), -1);
       for (unsigned int i=0; i<itsAnt1.size(); ++i) {
-        assert (itsAnt1[i] >= 0  &&  itsAnt1[i] < int(itsAntMap.size())  &&
-                itsAnt2[i] >= 0  &&  itsAnt2[i] < int(itsAntMap.size()));
+        if( ! (itsAnt1[i] >= 0  &&  itsAnt1[i] < int(itsAntMap.size())  &&
+               itsAnt2[i] >= 0  &&  itsAnt2[i] < int(itsAntMap.size())) )
+          throw std::runtime_error("Antenna map has an inconsistent size");
         itsAntMap[itsAnt1[i]] = 0;
         itsAntMap[itsAnt2[i]] = 0;
       }
@@ -158,9 +159,11 @@ namespace DP3 {
     {
       Record rec;
       String msg;
-      assert (fromMeas.toRecord (msg, rec));
+      if (!fromMeas.toRecord (msg, rec))
+        throw std::runtime_error("Could not copy MeasureHolder record to record");
       MeasureHolder mh2;
-      assert (mh2.fromRecord (msg, rec));
+      if (!mh2.fromRecord (msg, rec))
+        throw std::runtime_error("Could not copy record to MeasureHolder");
       return mh2;
     }
 

--- a/DPPP/DPInput.cc
+++ b/DPPP/DPInput.cc
@@ -63,9 +63,10 @@ namespace DP3 {
         // Only use the XX flags; no averaging done, thus navgtime=1.
         // (If any averaging was done, the flags would be in the buffer).
         IPosition shp(bufin.getFlags().shape());
-        assert (fullResFlags.shape()[0] == shp[1]  &&
-                fullResFlags.shape()[1] == 1  &&
-                fullResFlags.shape()[2] == shp[2]);
+        if (fullResFlags.shape()[0] != shp[1]  ||
+            fullResFlags.shape()[1] != 1  ||
+            fullResFlags.shape()[2] != shp[2])
+          throw std::runtime_error("Invalid shape of full res flags");
         objcopy (fullResFlags.data(), bufin.getFlags().data(),
                  fullResFlags.size(), 1, shp[0]);    // only copy XX.
         return fullResFlags;

--- a/DPPP/DPInput.cc
+++ b/DPPP/DPInput.cc
@@ -29,8 +29,6 @@
 #include <casacore/measures/Measures/MCPosition.h>
 #include <casacore/casa/Utilities/Copy.h>
 
-#include <assert.h>
-
 using namespace casacore;
 
 namespace DP3 {

--- a/DPPP/EstimateNew.cc
+++ b/DPPP/EstimateNew.cc
@@ -454,7 +454,8 @@ namespace DP3 {
         // Perform LSQ iteration.
         casacore::uInt rank;
         bool status = solver.solveLoop(rank, &(itsUnknowns[0]), true);
-        assert(status);
+        if(!status)
+          throw std::runtime_error("Solve failed");
         // Copy the unknowns to the full solution.
         fillSolution (unknownsIndex, srcSet);
         if (verbose > 13) {

--- a/DPPP/GainCal.cc
+++ b/DPPP/GainCal.cc
@@ -123,7 +123,6 @@ namespace DP3 {
                                               "applybeamtomodelcolumn", false);
         if (itsApplyBeamToModelColumn) {
           itsApplyBeamStep=ApplyBeam(input, parset, prefix, true);
-          assert(!itsApplyBeamStep.invert());
           itsResultStep = ResultStep::ShPtr(new ResultStep());
           itsApplyBeamStep.setNextStep(itsResultStep);
         }
@@ -144,8 +143,9 @@ namespace DP3 {
       if (itsMode == TECANDPHASE || itsMode == TEC) {
         defaultNChan = 1;
       }
+      else if(itsMode==TECSCREEN)
+        throw std::runtime_error("Can't solve with mode TECSCREEN");
       itsNChan = parset.getInt(prefix + "nchan", defaultNChan);
-      assert(itsMode!=TECSCREEN);
     }
 
     GainCal::~GainCal()
@@ -311,7 +311,8 @@ namespace DP3 {
       itsChunkStartTime = info().startTime();
 
       if (itsDebugLevel>0) {
-        assert(getInfo().nThreads()==1);
+        if(getInfo().nThreads()!=1)
+          throw std::runtime_error(nthreads should be 1 in debug mode");
         assert(itsTimeSlotsPerParmUpdate >= info().ntime());
         itsAllSolutions.resize(IPosition(6,
                                iS[0].numCorrelations(),

--- a/DPPP/GainCal.cc
+++ b/DPPP/GainCal.cc
@@ -312,7 +312,7 @@ namespace DP3 {
 
       if (itsDebugLevel>0) {
         if(getInfo().nThreads()!=1)
-          throw std::runtime_error(nthreads should be 1 in debug mode");
+          throw std::runtime_error("nthreads should be 1 in debug mode");
         assert(itsTimeSlotsPerParmUpdate >= info().ntime());
         itsAllSolutions.resize(IPosition(6,
                                iS[0].numCorrelations(),

--- a/DPPP/GridInterpolate.cc
+++ b/DPPP/GridInterpolate.cc
@@ -24,7 +24,6 @@
 
 #include <iostream>
 #include <vector>
-#include <cassert>
 #include <stdexcept>
 
 using namespace std;
@@ -38,7 +37,8 @@ namespace DP3 {
     if (ax_tgt.empty()) {
       return;
     }
-    assert(!ax_src.empty());
+    if(ax_src.empty())
+      throw std::invalid_argument("ax_src is empty");
 
     double lowmatch, highmatch;
 

--- a/DPPP/GridInterpolate.h
+++ b/DPPP/GridInterpolate.h
@@ -28,7 +28,6 @@
 // @brief Interpolate data from regular 2d grid to another
 
 #include <vector>
-#include <cassert>
 #include <stdexcept>
 
 namespace DP3 {

--- a/DPPP/H5ParmPredict.cc
+++ b/DPPP/H5ParmPredict.cc
@@ -57,29 +57,28 @@ namespace DP3 {
       H5Parm::SolTab soltab = h5parm.getSolTab(soltabName);
 
       vector<string> h5directions = soltab.getStringAxis("dir");
+      if(h5directions.empty())
+        throw std::runtime_error("H5Parm has empty dir axis");
 
       string operation = parset.getString(prefix+"operation", "replace");
 
       if (itsDirections.empty()) {
         itsDirections = h5directions;
       } else {
-        for (vector<string>::iterator it = itsDirections.begin();
-          // Check that all specified directions are in the h5parm
-          it != itsDirections.end(); ++it) {
-          if (find(h5directions.begin(), h5directions.end(), *it) ==
+        // Check that all specified directions are in the h5parm
+        for (const string& dirStr : itsDirections) {
+          if (find(h5directions.begin(), h5directions.end(), dirStr) ==
               h5directions.end()) {
-            throw Exception("Direction " + *it + " not found in " + itsH5ParmName);
+            throw Exception("Direction " + dirStr + " not found in " + itsH5ParmName);
           }
         }
       }
 
-      assert(!itsDirections.empty());
-
       for (unsigned int i=0; i<itsDirections.size(); ++i) {
         string directionStr = itsDirections[i];
         vector<string> directionVec; // each direction should be like '[patch1,patch2]'
-        assert(directionStr.size()>2 && directionStr[0]=='[' &&
-               directionStr[directionStr.size()-1]==']');
+        if(directionStr.size()<=2 || directionStr[0]!='[' || directionStr[directionStr.size()-1]!=']')
+          throw std::runtime_error("Invalid direction string: expecting array between square brackets, e.g. [a, b]");
         directionVec = StringUtil::tokenize(directionStr.substr(1, directionStr.size()-2), ",");
         Predict* predictStep = new Predict(input, parset, prefix, directionVec);
 

--- a/DPPP/MSUpdater.cc
+++ b/DPPP/MSUpdater.cc
@@ -105,7 +105,8 @@ namespace DP3 {
             break;
           }
         }
-        assert(colinfo.nfields()>0);
+        if(colinfo.nfields()==0)
+          throw std::runtime_error("Could not obtain column info");
         // When the storage manager is compressed, do not implicitly (re)compress it. Use TiledStMan instead.
         std::string dmType = colinfo.asString("TYPE");
         TableDesc td;
@@ -213,7 +214,8 @@ namespace DP3 {
           itsWeightColName = origWeightColName;
         }
       }
-      assert(itsWeightColName != "WEIGHT");
+      if(itsWeightColName == "WEIGHT")
+        throw std::runtime_error("Can't use WEIGHT column as spectral weights column");
       if (itsWeightColName != origWeightColName) {
         info().setWriteWeights();
       }

--- a/DPPP/MSWriter.cc
+++ b/DPPP/MSWriter.cc
@@ -442,7 +442,8 @@ namespace DP3 {
       Table inSPW  = itsReader->table().keywordSet().asTable("SPECTRAL_WINDOW");
       Table outSPW = Table(outName + "/SPECTRAL_WINDOW", Table::Update);
       Table outDD  = Table(outName + "/DATA_DESCRIPTION", Table::Update);
-      assert(outSPW.nrow() == outDD.nrow());
+      if(outSPW.nrow() != outDD.nrow())
+        throw std::runtime_error("nrow in SPECTRAL_WINDOW table is not the same as nrow in DATA_DESCRIPTION table");
       unsigned int spw = itsReader->spectralWindow();
       // Remove all rows before and after the selected band.
       // Do it from the end, otherwise row numbers change.
@@ -452,7 +453,6 @@ namespace DP3 {
           outDD.removeRow (i);
         }
       }
-      assert (outSPW.nrow() == 1);
       // Set nr of channels.
       ScalarColumn<Int> channum(outSPW, "NUM_CHAN");
       channum.fillColumn (itsNrChan);
@@ -654,7 +654,8 @@ namespace DP3 {
       if (ofShape[0] == chShape[0]*8) {
         Conversion::boolToBit (chars.data(), flags.data(), flags.size());
       } else {
-        assert(ofShape[0] < chShape[0]*8);
+        if(ofShape[0] > chShape[0]*8)
+          throw std::runtime_error("Incorrect shape of full res flags");
         const bool* flagsPtr = flags.data();
         uChar* charsPtr = chars.data();
         for (int i=0; i<ofShape[1]*ofShape[2]; ++i) {

--- a/DPPP/OneApplyCal.cc
+++ b/DPPP/OneApplyCal.cc
@@ -602,7 +602,7 @@ namespace DP3 {
                 itsParmDB->getDefValues(defParmNameAntenna).get(0,defValues);
                 if(defValues.size()!=1)
                   throw std::runtime_error("Multiple default values found in parmdb for " + defParmNameAntenna + ". " +
-                      " Did you unintentially overwrite an existing parmdb?");
+                      "Did you unintentially overwrite an existing parmdb?");
                 defValue=defValues.data()[0];
               }
               else if (itsParmDB->getDefValues(parmExpr).size() == 1) { //Default value

--- a/DPPP/OneApplyCal.cc
+++ b/DPPP/OneApplyCal.cc
@@ -86,7 +86,7 @@ namespace DP3 {
     {
 
       if (itsParmDBName.empty())
-        throw std::runtime_error("A parmdb should be provided");
+        throw std::runtime_error("A parmdb or h5parm should be provided");
 
       if (substep) {
         itsInvert=false;
@@ -141,7 +141,7 @@ namespace DP3 {
         itsDirection = 0;
         if (directionStr=="") {
           if(itsSolTab.hasAxis("dir") && itsSolTab.getAxis("dir").size!=1)
-            throw std::runtime_error("If the soltab contains a dir axis, it should be of size one");
+            throw std::runtime_error("If the soltab contains multiple directions, the direction to be applied in applycal should be specified");
           // If there is only one direction, silently assume it is the right one
         } else if (itsSolTab.hasAxis("dir") && itsSolTab.getAxis("dir").size>1) {
           itsDirection = itsSolTab.getDirIndex(directionStr);
@@ -315,9 +315,9 @@ namespace DP3 {
         itsParmExprs.push_back("Phase:0");
         itsParmExprs.push_back("Phase:1");
       } else if (itsCorrectType == AMPLITUDE) {
-         if(!itsUseH5Parm)
-          throw std::runtime_error("A H5Parm is required for amplitude correction");
-       itsParmExprs.push_back("Amplitude:0");
+          if(!itsUseH5Parm)
+            throw std::runtime_error("A H5Parm is required for amplitude correction");
+        itsParmExprs.push_back("Amplitude:0");
         itsParmExprs.push_back("Amplitude:1");
       } else {
         throw Exception("Correction type " +
@@ -597,12 +597,12 @@ namespace DP3 {
               Array<double> defValues;
               double defValue;
 
-              if (itsParmDB->getDefValues(parmExpr + ":" +
-                  string(info().antennaNames()[ant]) + name_postfix).size()==1) { // Default for antenna
-                itsParmDB->getDefValues(string(itsParmExprs[parmExprNum]) + ":" +
-                  string(info().antennaNames()[ant]) + name_postfix).get(0,defValues);
+              string defParmNameAntenna = parmExpr + ":" + string(info().antennaNames()[ant]) + name_postfix;
+              if (itsParmDB->getDefValues(defParmNameAntenna).size()==1) { // Default for antenna
+                itsParmDB->getDefValues(defParmNameAntenna).get(0,defValues);
                 if(defValues.size()!=1)
-                  throw std::runtime_error("Size of defValues != 1");
+                  throw std::runtime_error("Multiple default values found in parmdb for " + defParmNameAntenna + ". " +
+                      " Did you unintentially overwrite an existing parmdb?");
                 defValue=defValues.data()[0];
               }
               else if (itsParmDB->getDefValues(parmExpr).size() == 1) { //Default value
@@ -628,7 +628,7 @@ namespace DP3 {
       }
 
       if(parmvalues[0][0].size() > tfDomainSize) // Catches multiple matches
-        throw std::runtime_error("Multiple matches");
+        throw std::runtime_error("Parameter was found multiple times in ParmDB");
 
       double freq;
 

--- a/DPPP/PhaseShift.cc
+++ b/DPPP/PhaseShift.cc
@@ -131,8 +131,6 @@ namespace DP3 {
       int ncorr  = itsBuf.getData().shape()[0];
       int nchan  = itsBuf.getData().shape()[1];
       int nbl    = itsBuf.getData().shape()[2];
-      assert (itsPhasors.nrow() == (unsigned int)(nchan)  &&
-                 itsPhasors.ncolumn() == (unsigned int)(nbl));
       const double* mat1 = itsMat1.data();
       //# If ever in the future a time dependent phase center is used,
       //# the machine must be reset for each new time, thus each new call
@@ -219,7 +217,6 @@ namespace DP3 {
     void PhaseShift::fillTransMatrix (Matrix<double>& mat,
                                       double ra, double dec)
     {
-      assert (mat.nrow()==3 && mat.ncolumn()==3);
       double sinra  = sin(ra);
       double cosra  = cos(ra);
       double sindec = sin(dec);

--- a/DPPP/Predict.cc
+++ b/DPPP/Predict.cc
@@ -167,7 +167,7 @@ namespace DP3 {
       itsApplyCalStep=ApplyCal(input, parset, prefix, true,
                                itsDirectionsStr);
       if(itsOperation!="replace" && parset.getBool(prefix + "applycal.updateweights", false))
-        throw std::runtime_error("Weights cannot be updated when operation is not replace");
+        throw std::invalid_argument("Weights cannot be updated when operation is not replace");
       itsResultStep=new ResultStep();
       itsApplyCalStep.setNextStep(DPStep::ShPtr(itsResultStep));
     }
@@ -268,7 +268,7 @@ namespace DP3 {
     void Predict::setOperation(const std::string& operation) {
       itsOperation=operation;
       if(itsOperation!="replace" && itsOperation!="add" && itsOperation!="subtract")
-        throw std::runtime_error("Operation must be 'replace', 'add' or 'subtract'.");
+        throw std::invalid_argument("Operation must be 'replace', 'add' or 'subtract'.");
     }
 
     void Predict::show (std::ostream& os) const

--- a/DPPP/Predict.cc
+++ b/DPPP/Predict.cc
@@ -101,7 +101,8 @@ namespace DP3 {
       itsDebugLevel = parset.getInt (prefix + "debuglevel", 0);
       itsPatchList = vector<Patch::ConstPtr> ();
 
-      assert(File(itsSourceDBName).exists());
+      if(!File(itsSourceDBName).exists())
+        throw std::runtime_error("Specified source DB name does not exist");
       BBS::SourceDB sourceDB(BBS::ParmDBMeta("", itsSourceDBName), false);
 
       // Save directions specifications to pass to applycal
@@ -118,7 +119,6 @@ namespace DP3 {
         itsOneBeamPerPatch=parset.getBool (prefix + "onebeamperpatch", false);
 
         string mode=boost::to_lower_copy(parset.getString(prefix + "beammode","default"));
-        assert (mode=="default" || mode=="array_factor" || mode=="element");
         if (mode=="default") {
           itsBeamMode=FullBeamCorrection;
         } else if (mode=="array_factor") {
@@ -166,8 +166,8 @@ namespace DP3 {
       itsDoApplyCal=true;
       itsApplyCalStep=ApplyCal(input, parset, prefix, true,
                                itsDirectionsStr);
-      assert(!(itsOperation!="replace" &&
-               parset.getBool(prefix + "applycal.updateweights", false)));
+      if(itsOperation!="replace" && parset.getBool(prefix + "applycal.updateweights", false))
+        throw std::runtime_error("Weights cannot be updated when operation is not replace");
       itsResultStep=new ResultStep();
       itsApplyCalStep.setNextStep(DPStep::ShPtr(itsResultStep));
     }
@@ -267,8 +267,8 @@ namespace DP3 {
 
     void Predict::setOperation(const std::string& operation) {
       itsOperation=operation;
-      assert(itsOperation=="replace" || itsOperation=="add" ||
-             itsOperation=="subtract");
+      if(itsOperation!="replace" && itsOperation!="add" && itsOperation!="subtract")
+        throw std::runtime_error("Operation must be 'replace', 'add' or 'subtract'.");
     }
 
     void Predict::show (std::ostream& os) const

--- a/DPPP/ScaleData.cc
+++ b/DPPP/ScaleData.cc
@@ -149,7 +149,6 @@ namespace DP3 {
           }
         }
       }
-      assert (itsStationFactors.size() == nant);
       // Now calculate the factors per baseline,freq,pol.
       unsigned int nb = infoIn.nbaselines();
       unsigned int nf = freqs.size();

--- a/DPPP/SolTab.cc
+++ b/DPPP/SolTab.cc
@@ -194,7 +194,8 @@ namespace DP3 {
 
     // Get number of dimensions and size of all dimensions
     H5::DataSpace ds = val.getSpace();
-    assert (ds.getSimpleExtentNdims() == int(ndims));
+    if(ds.getSimpleExtentNdims() != int(ndims))
+      throw std::runtime_error("Something wrong with H5Parm: ds.getSimpleExtentNdims() != int(ndims)");
     hsize_t dims_out[ndims];
     ds.getSimpleExtentDims(dims_out);
 
@@ -293,7 +294,8 @@ namespace DP3 {
       } else if (_axes[i].name=="pol") {
         offset[i] = pol;
       } else {
-        assert(_axes[i].size == 1);
+        if(_axes[i].size != 1)
+          throw std::runtime_error("Could not find suitable axis in H5Parm");
         offset[i] = 0;
       }
     }
@@ -314,7 +316,7 @@ namespace DP3 {
   }
 
   void H5Parm::SolTab::setAntennas(const vector<string>& solAntennas) {
-    // TODO: assert that antenna is present in antenna table in solset
+    // TODO: check that antenna is present in antenna table in solset
     hsize_t dims[1];
     dims[0]=solAntennas.size();
 
@@ -400,11 +402,12 @@ namespace DP3 {
     } catch (H5::GroupIException& e) {
       throw Exception("SolTab has no table " + tableName);
     }
-    assert(dataspace.getSimpleExtentNdims()==1);
+    if(dataspace.getSimpleExtentNdims()!=1)
+      throw std::runtime_error("Something wrong with H5Parm: dataspace.getSimpleExtentNdims()!=1");
     hsize_t dims[1];
     dataspace.getSimpleExtentDims(dims);
 
-    // TODO: assert that DataType is String
+    // TODO: check that DataType is String
     hsize_t strLen = dataset.getDataType().getSize();
 
     char elNames[strLen*dims[0]];
@@ -476,7 +479,8 @@ namespace DP3 {
     } catch (H5::GroupIException& e) {
       throw Exception("SolTab " + getName() + " has no axis '" + axisname + "'");
     }
-    assert(dataspace.getSimpleExtentNdims()==1);
+    if(dataspace.getSimpleExtentNdims()!=1)
+      throw std::runtime_error("Something wrong with H5Parm: dataspace.getSimpleExtentNdims()!=1");
 
     hsize_t dims[1];
     dataspace.getSimpleExtentDims(dims);
@@ -543,7 +547,8 @@ namespace DP3 {
     } catch (H5::GroupIException& e) {
       throw Exception("SolTab " + getName() + " has no axis table for " + axisName);
     }
-    assert(dataspace.getSimpleExtentNdims()==1);
+    if(dataspace.getSimpleExtentNdims()!=1)
+      throw std::runtime_error("Something wrong with H5Parm: dataspace.getSimpleExtentNdims()!=1");
 
     hsize_t dims[1];
     dataspace.getSimpleExtentDims(dims);

--- a/DPPP/SolTab.cc
+++ b/DPPP/SolTab.cc
@@ -195,7 +195,7 @@ namespace DP3 {
     // Get number of dimensions and size of all dimensions
     H5::DataSpace ds = val.getSpace();
     if(ds.getSimpleExtentNdims() != int(ndims))
-      throw std::runtime_error("Something wrong with H5Parm: ds.getSimpleExtentNdims() != int(ndims)");
+      throw std::runtime_error("H5Parm is inconsistent: number of axis in data does not match number of axis in metadata");
     hsize_t dims_out[ndims];
     ds.getSimpleExtentDims(dims_out);
 
@@ -295,7 +295,7 @@ namespace DP3 {
         offset[i] = pol;
       } else {
         if(_axes[i].size != 1)
-          throw std::runtime_error("Could not find suitable axis in H5Parm");
+          throw std::runtime_error("Axis \"" + _axes[i].name + "\" in H5Parm is not understood");
         offset[i] = 0;
       }
     }
@@ -403,7 +403,7 @@ namespace DP3 {
       throw Exception("SolTab has no table " + tableName);
     }
     if(dataspace.getSimpleExtentNdims()!=1)
-      throw std::runtime_error("Something wrong with H5Parm: dataspace.getSimpleExtentNdims()!=1");
+      throw std::runtime_error("Invalid H5Parm: table \"" + tableName + "\" should be onedimensional");
     hsize_t dims[1];
     dataspace.getSimpleExtentDims(dims);
 
@@ -548,7 +548,7 @@ namespace DP3 {
       throw Exception("SolTab " + getName() + " has no axis table for " + axisName);
     }
     if(dataspace.getSimpleExtentNdims()!=1)
-      throw std::runtime_error("Something wrong with H5Parm: dataspace.getSimpleExtentNdims()!=1");
+      throw std::runtime_error("Invalid H5Parm: table \"" + axisName + "\" should be onedimensional");
 
     hsize_t dims[1];
     dataspace.getSimpleExtentDims(dims);

--- a/DPPP/SolTab.cc
+++ b/DPPP/SolTab.cc
@@ -195,7 +195,7 @@ namespace DP3 {
     // Get number of dimensions and size of all dimensions
     H5::DataSpace ds = val.getSpace();
     if(ds.getSimpleExtentNdims() != int(ndims))
-      throw std::runtime_error("H5Parm is inconsistent: number of axis in data does not match number of axis in metadata");
+      throw std::runtime_error("H5Parm is inconsistent: number of axes in data does not match number of axes in metadata");
     hsize_t dims_out[ndims];
     ds.getSimpleExtentDims(dims_out);
 

--- a/DPPP/SolTab.cc
+++ b/DPPP/SolTab.cc
@@ -5,6 +5,7 @@
 #include "../Common/StringUtil.h"
 
 #include <algorithm>
+#include <cassert>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>

--- a/DPPP/SourceDBUtil.cc
+++ b/DPPP/SourceDBUtil.cc
@@ -138,7 +138,7 @@ std::vector<Patch::ConstPtr> makePatches(SourceDB &sourceDB,
                                 componentsList[i].end()));
     std::vector<BBS::PatchInfo> patchInfo(sourceDB.getPatchInfo(-1, patchNames[i]));
     if (patchInfo.size() != 1)
-      throw std::runtime_error("patch should have size of one");
+      throw std::runtime_error("Patch \"" + patchNames[i] + "\" defined more than once in SourceDB");
     // Set the position and apparent flux of the patch.
     Position patchPosition;
     patchPosition[0] = patchInfo[0].getRa();

--- a/DPPP/SourceDBUtil.cc
+++ b/DPPP/SourceDBUtil.cc
@@ -58,7 +58,8 @@ std::vector<Patch::ConstPtr> makePatches(SourceDB &sourceDB,
     for (unsigned int i=0; i<nModel; ++i) {
       if (src.getPatchName() == patchNames[i]) {
         // Fetch position.
-        assert (src.getInfo().getRefType() == "J2000");
+        if (src.getInfo().getRefType() != "J2000")
+          throw std::runtime_error("Reference type should be J2000");
         Position position;
         position[0] = src.getRa();
         position[1] = src.getDec();
@@ -136,7 +137,8 @@ std::vector<Patch::ConstPtr> makePatches(SourceDB &sourceDB,
                                 componentsList[i].begin(),
                                 componentsList[i].end()));
     std::vector<BBS::PatchInfo> patchInfo(sourceDB.getPatchInfo(-1, patchNames[i]));
-    assert (patchInfo.size() == 1);
+    if (patchInfo.size() != 1)
+      throw std::runtime_error("patch should have size of one");
     // Set the position and apparent flux of the patch.
     Position patchPosition;
     patchPosition[0] = patchInfo[0].getRa();

--- a/DPPP/Split.cc
+++ b/DPPP/Split.cc
@@ -31,7 +31,6 @@
 
 #include <stddef.h>
 
-#include <cassert>
 #include <iostream>
 #include <string>
 #include <sstream>
@@ -53,15 +52,13 @@ namespace DP3 {
       replaceParmValues.resize(itsReplaceParms.size());
 
       vector<vector<string> >::iterator replaceParmValueIt = replaceParmValues.begin();
-      vector<string>::iterator replaceParmIt;
       unsigned int numSteps = 0;
-      for (replaceParmIt = itsReplaceParms.begin();
-           replaceParmIt != itsReplaceParms.end(); ++replaceParmIt) {
-        vector<string> parmValues = parset.getStringVector(*replaceParmIt);
+      for (const string& replaceParm : itsReplaceParms) {
+        vector<string> parmValues = parset.getStringVector(replaceParm);
         *(replaceParmValueIt++) = parmValues;
         if (numSteps > 0) {
           if(parmValues.size() != numSteps)
-            throw Exception("Each parameter in replaceparms should have the same number of items (expected " + std::to_string(numSteps) + ", got " + std::to_string(parmValues.size()) + " for step " + *replaceParmIt);
+            throw Exception("Each parameter in replaceparms should have the same number of items (expected " + std::to_string(numSteps) + ", got " + std::to_string(parmValues.size()) + " for step " + replaceParm);
         } else {
           numSteps = parmValues.size();
         }
@@ -80,7 +77,6 @@ namespace DP3 {
         firstStep->setPrevStep(this);
         itsSubsteps.push_back(firstStep);
       }
-      assert(itsSubsteps.size()>0);
     }
 
     Split::~Split()

--- a/ParmDB/ParmDB.cc
+++ b/ParmDB/ParmDB.cc
@@ -201,7 +201,7 @@ namespace BBS {
       string tabName = itsRep->getParmDBMeta().getTableName();
       map<string,int>::iterator pos = theirDBNames.find (tabName);
       if (pos == theirDBNames.end())
-				throw std::runtime_error("~ParmDB " + tabName + " not found in map");
+        throw std::runtime_error("~ParmDB " + tabName + " not found in map");
       assert (theirParmDBs[pos->second] == itsRep);
       theirParmDBs[pos->second] = 0;
       theirDBNames.erase (pos);

--- a/ParmDB/PatchInfo.cc
+++ b/ParmDB/PatchInfo.cc
@@ -79,7 +79,8 @@ namespace BBS {
     string patchName;
     int16_t cType;
     double apparentBrightness, ra, dec;
-    assert (bis.getStart ("patch") == 1);   // version must be 1
+    if (bis.getStart ("patch") != 1)   // version must be 1
+      throw std::runtime_error("Version of patch must be 1");
     bis >> patchName >> cType >> apparentBrightness >> ra >> dec;
     bis.getEnd();
     info = PatchInfo (patchName, ra, dec, cType, apparentBrightness);

--- a/ParmDB/SourceDBBlob.cc
+++ b/ParmDB/SourceDBBlob.cc
@@ -57,14 +57,15 @@ namespace BBS {
           itsFile.open (pdm.getTableName().c_str(), ios::in | ios::binary);
           itsCanWrite = false;
         }
-        assert (itsFile);
+        if (!itsFile)
+          throw std::runtime_error("Error opening file " + pdm.getTableName());
       }
     }
     if (forceNew) {
       itsFile.open (pdm.getTableName().c_str(),
                     ios::out | ios::in | ios::trunc | ios::binary);
       if (!itsFile)
-				throw std::runtime_error("SourceDB blob file " + pdm.getTableName() +
+        throw std::runtime_error("SourceDB blob file " + pdm.getTableName() +
                  " cannot be created");
     }
     itsBufIn   = std::shared_ptr<BlobIBufStream>(new BlobIBufStream(itsFile));
@@ -118,7 +119,7 @@ namespace BBS {
   {
     // Write at the end of the file.
     if (!itsCanWrite)
-			throw std::runtime_error("SourceDBBlob: file is not writable");
+      throw std::runtime_error("SourceDBBlob: file is not writable");
     itsFile.seekp (0, ios::end);
     unsigned int filePos = itsFile.tellp();
     *itsBlobOut << PatchInfo(patchName, ra, dec, catType, apparentBrightness);

--- a/ParmDB/SourceInfo.cc
+++ b/ParmDB/SourceInfo.cc
@@ -123,7 +123,8 @@ namespace BBS {
   {
     int16_t version, type;
     bis >> version >> itsName >> type >> itsRefType;
-    assert (version == 1 || version == 2);
+    if (version != 1 && version != 2)
+      throw std::runtime_error("Version of sourcedb must be 1 or 2");
     if (version >= 2) {
      bis >> itsHasLogarithmicSI;
     } else {


### PR DESCRIPTION
Pull request to finish #1. I think the rule should be that any error caused by bad input
(parset error, command line error, data format error, etc) should throw an exception.
Any check on internal consistency or logic can be an assert(), so that they are disabled when
building in RELEASE mode. Some of the e.g. parset errors are now checked with 'assert',
which means that they won't be checked when build in RELEASE mode. Moreover, an assert
error is not very helpful for the user, an exception is at least a slightly friendlier
description of the problem.