### PR TITLE
Test building with IDG

### DIFF
--- a/.travis/Dockerfile_lofar
+++ b/.travis/Dockerfile_lofar
@@ -7,12 +7,16 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && \
     libboost-filesystem-dev libboost-system-dev libboost-date-time-dev \
     libboost-signals-dev libboost-program-options-dev libboost-test-dev \
     libxml2-dev libpng-dev pkg-config aoflagger-dev \
-    libgtkmm-3.0-dev
+    libgtkmm-3.0-dev git wget libfftw3-dev
 
 ADD . /src
 WORKDIR /src
 
-RUN mkdir /build && cd /build && cmake ../src
+# Build latest IDG master from source
+RUN mkdir /idg && cd /idg && git clone https://gitlab.com/astron-idg/idg.git src
+RUN mkdir /idg/build && cd /idg/build && cmake -DCMAKE_INSTALL_PREFIX=/usr/local ../src && make install -j2
+
+RUN mkdir /build && cd /build && cmake -DCMAKE_PREFIX_PATH=/usr/local ../src
 RUN ln -s /usr/include/casacore/measures /usr/include && ln -s /usr/include/casacore/ms /usr/include
 RUN cd /build && make -j2
 RUN cd /build && make check -j2


### PR DESCRIPTION
Building with `-DCMAKE_PREFIX_PATH=/usr/local/share` should not be necessary; it should work with `-DCMAKE_PREFIX_PATH=/usr/local/`. This should be resolved in IDG. For now, this is the only way I could get it to build.