### PR TITLE
Beam keywords when not inverting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,6 +272,7 @@ add_executable(runtests EXCLUDE_FROM_ALL ${RUNTEST_SOURCES})
 
 target_link_libraries(runtests ${EXTRA_LIBRARIES} ${LOFAR_STATION_RESPONSE_LIB})
 
+add_test(buildruntests "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target runtests)
 # Add each test as a cmake test (only for tests added with BOOST_AUTO_TEST_SUITE and BOOST_AUTO_TEST_CASE)
 foreach(TEST_FILENAME ${TEST_FILENAMES})
   file(READ ${TEST_FILENAME} TEST_FILE_CONTENTS)
@@ -285,6 +286,7 @@ foreach(TEST_FILENAME ${TEST_FILENAMES})
   foreach(FOUND_TEST ${FOUND_TESTS})
     string(REGEX REPLACE ".*\\( *([A-Za-z_0-9]+) *\\).*" "\\1" TEST_NAME ${FOUND_TEST})
     add_test(NAME "${TESTSUITE_NAME}.${TEST_NAME}" COMMAND runtests --run_test=${TESTSUITE_NAME}/${TEST_NAME} --catch_system_error=yes)
+    set_tests_properties(${TESTSUITE_NAME}.${TEST_NAME} PROPERTIES DEPENDS buildruntests)
   endforeach()
 endforeach()
 

--- a/DPPP/ApplyBeam.cc
+++ b/DPPP/ApplyBeam.cc
@@ -119,10 +119,19 @@ namespace DP3 {
         itsDirection = MDirection(q0, q1, type);
       }
       
-      if(info().beamCorrectionMode() != NoBeamCorrection)
-        throw std::runtime_error("In applying the beam: the metadata of this observation indicate that the beam has already been applied");
-      info().setBeamCorrectionMode(itsMode);
-      info().setBeamCorrectionDir(itsDirection);
+      if(itsInvert)
+      {
+        if(info().beamCorrectionMode() != NoBeamCorrection)
+          throw std::runtime_error("In applying the beam (with invert=true): the metadata of this observation indicate that the beam has already been applied");
+        info().setBeamCorrectionMode(itsMode);
+        info().setBeamCorrectionDir(itsDirection);
+      }
+      else {
+        if(info().beamCorrectionMode() == NoBeamCorrection)
+          throw std::runtime_error("In applying the beam (with invert=false): the metadata of this observation indicate that the beam has not yet been applied");
+        info().setBeamCorrectionMode(NoBeamCorrection);
+        // TODO itsDirection should always be equal to info().beamCorrectionDir() here?
+      }
 
       const size_t nSt = info().nantenna();
       const size_t nCh = info().nchan();


### PR DESCRIPTION
Jishnu was trying to use an applybeam step with `invert=false` and found this incorrectly reported:

```
std exception detected: In applying the beam: the metadata of
this observation indicate that the beam has already been applied
```