### PR TITLE
Simplify locking for HDF5

### DIFF
--- a/DPPP/ApplyCal.cc
+++ b/DPPP/ApplyCal.cc
@@ -119,14 +119,14 @@ namespace DP3 {
       }
     }
 
-    bool ApplyCal::process (const DPBuffer& bufin, std::mutex* hdf5Mutex)
+    bool ApplyCal::process (const DPBuffer& bufin)
     {
       const DP3::DPPP::DPStep::ShPtr& step = getNextStep();
       auto oneApplyCalPtr = std::dynamic_pointer_cast<OneApplyCal>(step);
-      if(oneApplyCalPtr == nullptr || hdf5Mutex == nullptr)
+      if(oneApplyCalPtr == nullptr)
         step->process(bufin);
       else
-        oneApplyCalPtr->process(bufin, hdf5Mutex);
+        oneApplyCalPtr->process(bufin);
       return true;
     }
 

--- a/DPPP/ApplyCal.h
+++ b/DPPP/ApplyCal.h
@@ -33,7 +33,6 @@
 #include "OneApplyCal.h"
 
 #include <utility>
-#include <mutex>
 
 namespace DP3 {
 
@@ -60,16 +59,8 @@ namespace DP3 {
       // Process the data.
       // It keeps the data.
       // When processed, it invokes the process function of the next step.
-      virtual bool process (const DPBuffer& buffer)
-      {
-        return process(buffer, nullptr);
-      }
+      virtual bool process (const DPBuffer& buffer);
 
-      // When multi-threading, this method must be used over
-      // process(), to make sure that calls to hdf5 are
-      // synchronized
-      bool process (const DPBuffer&, std::mutex* hdf5Mutex);
-      
       // Finish the processing of this step and subsequent steps.
       virtual void finish();
 

--- a/DPPP/OneApplyCal.h
+++ b/DPPP/OneApplyCal.h
@@ -70,12 +70,7 @@ namespace DP3 {
       // Process the data.
       // It keeps the data.
       // When processed, it invokes the process function of the next step.
-      virtual bool process (const DPBuffer& buffer)
-      {
-        return process(buffer, nullptr);
-      }
-
-      bool process (const DPBuffer&, std::mutex* hdf5Mutex);
+      virtual bool process (const DPBuffer& buffer);
       
       // Finish the processing of this step and subsequent steps.
       virtual void finish();
@@ -95,7 +90,7 @@ namespace DP3 {
 
     private:
       // Read parameters from the associated parmdb and store them in itsParms
-      void updateParms (const double bufStartTime, std::mutex* hdf5Mutex);
+      void updateParms (const double bufStartTime);
 
       // If needed, show the flag counts.
       virtual void showCounts (std::ostream&) const;
@@ -146,6 +141,8 @@ namespace DP3 {
       bool            itsUseAP;      //# use ampl/phase or real/imag
       hsize_t         itsDirection;
       NSTimer         itsTimer;
+
+      static std::mutex theirHDF5Mutex; // Prevent parallel access to HDF5
     };
 
   } //# end namespace

--- a/DPPP/Predict.cc
+++ b/DPPP/Predict.cc
@@ -434,10 +434,7 @@ namespace DP3 {
 
       // Call ApplyCal step
       if (itsDoApplyCal) {
-        if(itsMeasuresMutex == nullptr)
-          itsApplyCalStep.process(itsTempBuffer);
-        else
-          itsApplyCalStep.process(itsTempBuffer, itsMeasuresMutex);
+        itsApplyCalStep.process(itsTempBuffer);
         itsTempBuffer=itsResultStep->get();
         tdata=itsTempBuffer.getData().data();
       }


### PR DESCRIPTION
There was a case where the HDF5 mutex was not set when calling ApplyCal
from nested threads. Rather than trying to pass the mutex around, I've
introduced a static mutex, which also cleans up a bit. This mutex is
used only for reading HDF5, so is not in any critical part of execution.

Solves #167