### PR TITLE
Make Stokes I-only predict mode work with array-factor beam

### DIFF
--- a/DPPP/ApplyBeam.h
+++ b/DPPP/ApplyBeam.h
@@ -74,7 +74,7 @@ namespace DP3 {
         // If apply beam is called from multiple threads, it needs the thread index
         // to determine what scratch space to use etc.
         bool processMultithreaded(const DPBuffer&, size_t thread);
-        
+
         // Finish the processing of this step and subsequent steps.
         virtual void finish();
 
@@ -99,6 +99,17 @@ namespace DP3 {
             const LOFAR::StationResponse::vector3r_t& tiledir,
             const std::vector<LOFAR::StationResponse::Station::Ptr>& antBeamInfo,
             std::vector<LOFAR::StationResponse::matrix22c_t>& beamValues,
+            bool useChannelFreq, bool invert, int mode,
+            bool doUpdateWeights=false);
+
+        template<typename T>
+        static void applyBeamStokesIArrayFactor(
+            const DPInfo& info, double time, T* data0, float* weight0,
+            const LOFAR::StationResponse::vector3r_t& srcdir,
+            const LOFAR::StationResponse::vector3r_t& refdir,
+            const LOFAR::StationResponse::vector3r_t& tiledir,
+            const std::vector<LOFAR::StationResponse::Station::Ptr>& antBeamInfo,
+            std::vector<LOFAR::StationResponse::complex_t>& beamValues,
             bool useChannelFreq, bool invert, int mode,
             bool doUpdateWeights=false);
 

--- a/DPPP/Predict.h
+++ b/DPPP/Predict.h
@@ -123,7 +123,8 @@ namespace DP3 {
       void addBeamToData (Patch::ConstPtr patch, double time,
                                    const LOFAR::StationResponse::vector3r_t& refdir,
                                    const LOFAR::StationResponse::vector3r_t& tiledir,
-                                   unsigned int thread, unsigned int nSamples, dcomplex* data0);
+                                   unsigned int thread, unsigned int nSamples,
+                                   dcomplex* data0, bool stokesIOnly);
 #endif
       //# Data members.
       DPInput*         itsInput;
@@ -159,6 +160,7 @@ namespace DP3 {
       // The info needed to calculate the station beams.
       std::vector<std::vector<LOFAR::StationResponse::Station::Ptr> > itsAntBeamInfo;
       std::vector<std::vector<LOFAR::StationResponse::matrix22c_t> >  itsBeamValues;
+      std::vector<std::vector<LOFAR::StationResponse::complex_t> >  itsBeamValuesSingle;
       BeamCorrectionMode itsBeamMode;
 #endif
       std::vector<casacore::MeasFrame>                    itsMeasFrames;


### PR DESCRIPTION
Currently, predict cannot use the Stokes I-only mode (which predicts only Stokes I if the sky model is unpolarized) when the beam is applied, as the beam effects are generally non-scalar. However, if only the array factor of the beam is applied, then the beam effect is a scalar one. This pull request allows the Stokes I-only predict mode to work with the array factor beam, improving the speed by ~50% and decreasing the memory usage.