### PR TITLE
Fix confusing error when something is wrong with the model

### DIFF
--- a/DPPP/Predict.cc
+++ b/DPPP/Predict.cc
@@ -110,9 +110,16 @@ namespace DP3 {
       ss << sourcePatterns;
       itsDirectionsStr = ss.str();
 
-      vector<string> patchNames=makePatchList(sourceDB, sourcePatterns);
-      itsPatchList = makePatches (sourceDB, patchNames, patchNames.size());
-
+      vector<string> patchNames;
+      try {
+        patchNames = makePatchList(sourceDB, sourcePatterns);
+        itsPatchList = makePatches (sourceDB, patchNames, patchNames.size());
+      }
+      catch(std::exception& exception)
+      {
+        throw std::runtime_error(std::string("Something went wrong while reading the source model. The error was: ") + exception.what());
+      }
+      
 #ifdef HAVE_LOFAR_BEAM
       if (itsApplyBeam) {
         itsUseChannelFreq=parset.getBool (prefix + "usechannelfreq", true);


### PR DESCRIPTION
When a model (patch/source name?) contains incorrect symbols, like "(" or "'", DP3 would give the following impossible to understand
exception:
`std exception detected: Regex: invalid regular expression component ( given (Unmatched \()`

I've now made sure that the exception is at least mentioning the problem is in the model.