### PR TITLE
Calculate allocatable size based on available mem

### DIFF
--- a/IDGPredict/FacetImage.h
+++ b/IDGPredict/FacetImage.h
@@ -102,6 +102,7 @@ public:
   { return std::move(_data[spectralTerm]); }
   
 private:
+  
   Facet clippedFacet(const Facet& input, int width, int height)
   {
     Facet clippedFacet(input);

--- a/IDGPredict/FacetPredict.h
+++ b/IDGPredict/FacetPredict.h
@@ -97,7 +97,8 @@ public:
     long int pageCount = sysconf(_SC_PHYS_PAGES), pageSize = sysconf(_SC_PAGE_SIZE);
     int64_t memory = (int64_t) pageCount * (int64_t) pageSize;
     // Allow the directions together to use 1/4th of the available memory for the vis buffers.
-    size_t allocatableTimesteps = idg::api::BufferSet::get_allocatable_ntimesteps(memory/4/_images.size(), _nr_stations, maxChannels);
+    uint64_t memPerTimestep = idg::api::BufferSet::get_memory_per_timestep(_nr_stations, maxChannels);
+    size_t allocatableTimesteps = memory/4/_images.size() / memPerTimestep;
     // TODO once a-terms are supported, this should include the size required for the a-terms.
     std::cout << "Allocatable timesteps per direction: " << allocatableTimesteps << '\n';
     

--- a/IDGPredict/FacetPredict.h
+++ b/IDGPredict/FacetPredict.h
@@ -90,7 +90,18 @@ public:
   {
     _buffersets.clear();
     idg::api::Type proxyType = idg::api::Type::CPU_OPTIMIZED;
-    int buffersize = 256;
+    
+    size_t maxChannels = 0;
+    for(std::vector<double>& band : _bands)
+      maxChannels = std::max(maxChannels, band.size());
+    long int pageCount = sysconf(_SC_PHYS_PAGES), pageSize = sysconf(_SC_PAGE_SIZE);
+    int64_t memory = (int64_t) pageCount * (int64_t) pageSize;
+    // Allow the directions together to use 1/4th of the available memory for the vis buffers.
+    size_t allocatableTimesteps = idg::api::BufferSet::get_allocatable_ntimesteps(memory/4/_images.size(), _nr_stations, maxChannels);
+    // TODO once a-terms are supported, this should include the size required for the a-terms.
+    std::cout << "Allocatable timesteps per direction: " << allocatableTimesteps << '\n';
+    
+    int buffersize = std::max(allocatableTimesteps, size_t(1));
     idg::api::options_type options;
     IdgConfiguration::Read(proxyType, buffersize, options);
     std::vector<ao::uvector<double>> data(_readers.size());

--- a/IDGPredict/FacetPredict.h
+++ b/IDGPredict/FacetPredict.h
@@ -96,8 +96,9 @@ public:
       maxChannels = std::max(maxChannels, band.size());
     long int pageCount = sysconf(_SC_PHYS_PAGES), pageSize = sysconf(_SC_PAGE_SIZE);
     int64_t memory = (int64_t) pageCount * (int64_t) pageSize;
-    // Allow the directions together to use 1/4th of the available memory for the vis buffers.
     uint64_t memPerTimestep = idg::api::BufferSet::get_memory_per_timestep(_nr_stations, maxChannels);
+    memPerTimestep *= 2; // IDG uses two internal buffer
+    // Allow the directions together to use 1/4th of the available memory for the vis buffers.
     size_t allocatableTimesteps = memory/4/_images.size() / memPerTimestep;
     // TODO once a-terms are supported, this should include the size required for the a-terms.
     std::cout << "Allocatable timesteps per direction: " << allocatableTimesteps << '\n';


### PR DESCRIPTION
One-fourth of the total memory is divided over the visibility buffers for all the directions. This should fix
issues David is having with memory crashes.

This commit requires the currently unmerged idg `calculate-memsize-of-buffer` branch.