### PR TITLE
Fix incorrect refantenna check

### DIFF
--- a/DDECal/TECConstraint.cc
+++ b/DDECal/TECConstraint.cc
@@ -70,7 +70,7 @@ void TECConstraintBase::applyReferenceAntenna(std::vector<std::vector<dcomplex> 
       break;
   }
   // All antennas are flagged, use first one (will lead to NaNs for this solint)
-  if (refAntenna == _nChannelBlocks)
+  if (refAntenna == _nAntennas)
     refAntenna = 0;
 
   for(size_t ch=0; ch!=_nChannelBlocks; ++ch)


### PR DESCRIPTION
Possible fix for #212 , crash related to TECConstraint.
Bug was introduced in #191 . Bug should only lead to a crash when all antennas are >20% flagged, which is inconsistent with what Francesco reports in https://github.com/lofar-astron/DP3/issues/212#issuecomment-583316960 . Nevertheless, this commit fixes a bug, and I don't see any other issues in the refant calculation.

This bug was btw already more or less mentioned by me in my review of #191, apparently the fix didn't make it properly and it got merged unnoticed :( .