### PR TITLE
Make it possible to correct for beam a second time

### DIFF
--- a/DPPP/ApplyBeam.h
+++ b/DPPP/ApplyBeam.h
@@ -99,7 +99,7 @@ namespace DP3 {
             const LOFAR::StationResponse::vector3r_t& tiledir,
             const std::vector<LOFAR::StationResponse::Station::Ptr>& antBeamInfo,
             std::vector<LOFAR::StationResponse::matrix22c_t>& beamValues,
-            bool useChannelFreq, bool invert, int mode,
+            bool useChannelFreq, bool invert, BeamCorrectionMode mode,
             bool doUpdateWeights=false);
 
         template<typename T>
@@ -110,7 +110,7 @@ namespace DP3 {
             const LOFAR::StationResponse::vector3r_t& tiledir,
             const std::vector<LOFAR::StationResponse::Station::Ptr>& antBeamInfo,
             std::vector<LOFAR::StationResponse::complex_t>& beamValues,
-            bool useChannelFreq, bool invert, int mode,
+            bool useChannelFreq, bool invert, BeamCorrectionMode mode,
             bool doUpdateWeights=false);
 
       private:
@@ -127,8 +127,12 @@ namespace DP3 {
         std::vector<string>       itsDirectionStr;
         casacore::MDirection itsDirection;
         bool                 itsUseChannelFreq;
-        //Position             itsPhaseRef;
         BeamCorrectionMode   itsMode;
+        
+        // If a beam had already been applied before running this step, that beam
+        // needs to undone; hence we register that beam info here:
+        casacore::MDirection itsDirectionAtStart;
+        BeamCorrectionMode itsModeAtStart;
 
         unsigned int                 itsDebugLevel;
 

--- a/DPPP/DPInfo.h
+++ b/DPPP/DPInfo.h
@@ -47,6 +47,17 @@ namespace DP3 {
       ArrayFactorBeamCorrection = 2,
       ElementBeamCorrection = 3
     };
+    
+    inline const char* BeamCorrectionModeToString(BeamCorrectionMode mode)
+    {
+      switch(mode) {
+        default:
+        case NoBeamCorrection: return "none";
+        case FullBeamCorrection: return "full";
+        case ArrayFactorBeamCorrection: return "array_factor";
+        case ElementBeamCorrection: return "element";
+      }
+    }
 
     // @ingroup NDPPP
 


### PR DESCRIPTION
This makes it e.g. possible to first apply the dipole beam to some direction and then the full beam when phased to another direction. This was requested by Frits. 

When `invert=true` (i.e. normal situation when applying beam to data), and the beam has already been applied to a certain direction, this is first undone and then the requested beam to the requested direction is applied. Some examples:
- Applying an `invert=true` beam to direction A, then again to direction A, is now accepted, and ends up with the beam in direction A (second run doesn't change anything).
- Applying an `invert=true` element beam to direction A, then applying an `invert=true` array beam to direction B, would end up with the *array beam* applied to direction B (i.e. element beam to direction A is undone).

Fully negating the beam having applied it is also possible (and was already possible). It requires an `invert=false` beam correction with the same direction and mode setting as was applied. The `invert=xxx` option is pretty confusing, and I'll file a ticket that we should make the beam setting such that we specify what we want as output, not what operation we want to do.

Fixes #221.