### PR TITLE
Change check for pre-64bit rownrs to casacore 3.4

### DIFF
--- a/DPPP/DPBuffer.h
+++ b/DPPP/DPBuffer.h
@@ -117,7 +117,7 @@ namespace DP3 {
     //    the data immediately (e.g. Averager).
     // The DPInput::fetch functions come in those 2 flavours.
 
-#if CASACORE_MAJOR_VERSION<3 || (CASACORE_MAJOR_VERSION==3 && CASACORE_MINOR_VERSION<3)
+#if CASACORE_MAJOR_VERSION<3 || (CASACORE_MAJOR_VERSION==3 && CASACORE_MINOR_VERSION<4)
     typedef unsigned int rownr_t;
 #else
     typedef casacore::rownr_t rownr_t;

--- a/DPPP/MultiMSReader.cc
+++ b/DPPP/MultiMSReader.cc
@@ -154,7 +154,7 @@ namespace DP3 {
       }
       Vector<rownr_t> index;
 
-#if CASACORE_MAJOR_VERSION<3 || (CASACORE_MAJOR_VERSION==3 && CASACORE_MINOR_VERSION<3)
+#if CASACORE_MAJOR_VERSION<3 || (CASACORE_MAJOR_VERSION==3 && CASACORE_MINOR_VERSION<4)
       GenSortIndirect<double>::sort (index, freqs);
 #else
       GenSortIndirect<double, rownr_t>::sort (index, freqs);

--- a/ParmDB/ParmDBCasa.h
+++ b/ParmDB/ParmDBCasa.h
@@ -42,7 +42,7 @@ namespace BBS {
   // @ingroup ParmDB
   // @{
 
-#if CASACORE_MAJOR_VERSION<3 || (CASACORE_MAJOR_VERSION==3 && CASACORE_MINOR_VERSION<3)
+#if CASACORE_MAJOR_VERSION<3 || (CASACORE_MAJOR_VERSION==3 && CASACORE_MINOR_VERSION<4)
   typedef unsigned int rownr_t;
 #else
   typedef casacore::rownr_t rownr_t;

--- a/ParmDB/SourceDBCasa.h
+++ b/ParmDB/SourceDBCasa.h
@@ -42,7 +42,7 @@ namespace BBS {
   // @ingroup ParmDB
   // @{
 
-#if CASACORE_MAJOR_VERSION<3 || (CASACORE_MAJOR_VERSION==3 && CASACORE_MINOR_VERSION<3)
+#if CASACORE_MAJOR_VERSION<3 || (CASACORE_MAJOR_VERSION==3 && CASACORE_MINOR_VERSION<4)
   typedef unsigned int rownr_t;
 #else
   typedef casacore::rownr_t rownr_t;


### PR DESCRIPTION
I guessed that casacore 3.3.0 (to be released in an hour) would have the
PR for 64 bit rownr support merged, but it will likely follow in 3.4.0.