### PR TITLE
Fix compilation error due to casacore regex changes

### DIFF
--- a/DPPP/DPRun.cc
+++ b/DPPP/DPRun.cc
@@ -275,7 +275,7 @@ namespace DP3 {
             casacore::Directory dir(dirName);
             // Use the basename as the file name pattern.
             casacore::DirectoryIterator dirIter (dir,
-                                             casacore::Regex::fromPattern(path.baseName()));
+              casacore::Regex(casacore::Regex::fromPattern(path.baseName())));
             while (!dirIter.pastEnd()) {
               names.push_back (dirName + '/' + dirIter.name());
               dirIter++;


### PR DESCRIPTION
Fixes #231. Recent changes in casacore, in particular the use of std::regex, have removed an implicit constructor for casacore::regex, requiring explicit calling of the constructor.