### PR TITLE
Fix exception when reading sourcedb caused by casacore 64bit transition

### DIFF
--- a/ParmDB/SourceDBCasa.h
+++ b/ParmDB/SourceDBCasa.h
@@ -203,7 +203,7 @@ namespace BBS {
     std::set<std::string> itsPatchSet;
     std::set<std::string> itsSourceSet;
     bool             itsSetsFilled;
-    casacore::Vector<casacore::uInt> itsRowNr;
+    casacore::Vector<rownr_t> itsRowNr;
   };
 
   // @}


### PR DESCRIPTION
Fixes the following exception when using sourcedbs:

`std exception detected: Something went wrong while reading the source model. The error was: Error in select expression: select expression result on table /data/Data/DeconvChTest-2020-05-25/testmodel.sourcedb/SOURCES is not Bool scalar`