### PR TITLE
Add step for setting beam keywords

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,22 +147,60 @@ add_library(IDGPredict OBJECT
 set(IDGPREDICT_OBJECT $<TARGET_OBJECTS:IDGPredict>)
 
 add_library(DPPP_OBJ OBJECT
-  DPPP/DPRun.cc DPPP/DPStep.cc DPPP/DPInput.cc DPPP/DPBuffer.cc
-  DPPP/DPInfo.cc DPPP/DPLogger.cc DPPP/ProgressMeter.cc DPPP/FlagCounter.cc
-  DPPP/UVWCalculator.cc  DPPP/BaselineSelection.cc DPPP/ApplyCal.cc
-  DPPP/MSReader.cc DPPP/MultiMSReader.cc DPPP/MSWriter.cc DPPP/MSUpdater.cc
-  DPPP/Counter.cc DPPP/Averager.cc DPPP/MedFlagger.cc DPPP/PreFlagger.cc
-  DPPP/UVWFlagger.cc DPPP/StationAdder.cc DPPP/ScaleData.cc DPPP/Filter.cc 
-  DPPP/PhaseShift.cc DPPP/Demixer.cc DPPP/Position.cc DPPP/Stokes.cc 
-  DPPP/SourceDBUtil.cc DPPP/Apply.cc DPPP/EstimateMixed.cc DPPP/EstimateNew.cc 
-  DPPP/Simulate.cc DPPP/Simulator.cc DPPP/SubtractMixed.cc DPPP/SubtractNew.cc
-  DPPP/ModelComponent.cc DPPP/PointSource.cc DPPP/GaussianSource.cc DPPP/Patch.cc
-  DPPP/ModelComponentVisitor.cc DPPP/GainCal.cc DPPP/GainCalAlgorithm.cc
-  DPPP/Predict.cc DPPP/OneApplyCal.cc
-  DPPP/PhaseFitter.cc DPPP/H5Parm.cc DPPP/SolTab.cc 
-  DPPP/DummyStep.cc DPPP/H5ParmPredict.cc DPPP/GridInterpolate.cc DPPP/Upsample.cc
-  DPPP/Split.cc
+  DPPP/Apply.cc
+  DPPP/ApplyCal.cc
+  DPPP/Averager.cc
+  DPPP/BaselineSelection.cc
+  DPPP/Counter.cc
+  DPPP/Demixer.cc
+  DPPP/DPBuffer.cc
+  DPPP/DPInfo.cc
+  DPPP/DPInput.cc
+  DPPP/DPLogger.cc
+  DPPP/DPRun.cc
+  DPPP/DPStep.cc
+  DPPP/DummyStep.cc
+  DPPP/EstimateMixed.cc
+  DPPP/EstimateNew.cc
+  DPPP/Filter.cc
+  DPPP/FlagCounter.cc
+  DPPP/GainCal.cc
+  DPPP/GainCalAlgorithm.cc
+  DPPP/GaussianSource.cc
+  DPPP/GridInterpolate.cc
+  DPPP/H5Parm.cc
+  DPPP/H5ParmPredict.cc
   DPPP/Interpolate.cc
+  DPPP/MedFlagger.cc
+  DPPP/ModelComponent.cc
+  DPPP/ModelComponentVisitor.cc
+  DPPP/MSReader.cc
+  DPPP/MSUpdater.cc
+  DPPP/MSWriter.cc
+  DPPP/MultiMSReader.cc
+  DPPP/OneApplyCal.cc
+  DPPP/Patch.cc
+  DPPP/PhaseFitter.cc
+  DPPP/PhaseShift.cc
+  DPPP/PointSource.cc
+  DPPP/Position.cc
+  DPPP/Predict.cc
+  DPPP/PreFlagger.cc
+  DPPP/ProgressMeter.cc
+  DPPP/ScaleData.cc
+  DPPP/SetBeam.cc
+  DPPP/Simulate.cc
+  DPPP/Simulator.cc
+  DPPP/SolTab.cc
+  DPPP/SourceDBUtil.cc
+  DPPP/Split.cc
+  DPPP/StationAdder.cc
+  DPPP/Stokes.cc
+  DPPP/SubtractMixed.cc
+  DPPP/SubtractNew.cc
+  DPPP/Upsample.cc
+  DPPP/UVWCalculator.cc
+  DPPP/UVWFlagger.cc
   ${LOFAR_DEPENDENT_FILES}
 )
 set(DPPP_OBJECT $<TARGET_OBJECTS:DPPP_OBJ>)

--- a/DPPP/ApplyBeam.cc
+++ b/DPPP/ApplyBeam.cc
@@ -133,7 +133,13 @@ namespace DP3 {
         if(info().beamCorrectionMode() != itsMode)
           throw std::runtime_error(std::string("applybeam step with invert=false has incorrect mode: input has ") +
           BeamCorrectionModeToString(info().beamCorrectionMode()) + ", requested to correct for " + BeamCorrectionModeToString(itsMode));
-        if(info().beamCorrectionDir().getValue() != itsDirection.getValue())
+        double
+          ra1 = info().beamCorrectionDir().getValue().getValue()[0],
+          dec1 = info().beamCorrectionDir().getValue().getValue()[1],
+          ra2 = itsDirection.getValue().getValue()[0],
+          dec2 = itsDirection.getValue().getValue()[0];
+        double raDist = std::fabs(ra1 - ra2), decDist = std::fabs(dec1 - dec2);
+        if(raDist > 1e-9 && decDist > 1e-9)
         {
           std::ostringstream str;
           str << "applybeam step with invert=false has incorrect direction: input is for " << 

--- a/DPPP/ApplyBeam.cc
+++ b/DPPP/ApplyBeam.cc
@@ -137,9 +137,9 @@ namespace DP3 {
           ra1 = info().beamCorrectionDir().getValue().getValue()[0],
           dec1 = info().beamCorrectionDir().getValue().getValue()[1],
           ra2 = itsDirection.getValue().getValue()[0],
-          dec2 = itsDirection.getValue().getValue()[0];
+          dec2 = itsDirection.getValue().getValue()[1];
         double raDist = std::fabs(ra1 - ra2), decDist = std::fabs(dec1 - dec2);
-        if(raDist > 1e-9 && decDist > 1e-9)
+        if(raDist > 1e-9 || decDist > 1e-9)
         {
           std::ostringstream str;
           str << "applybeam step with invert=false has incorrect direction: input is for " << 

--- a/DPPP/ApplyBeam.cc
+++ b/DPPP/ApplyBeam.cc
@@ -48,8 +48,6 @@
 #include <utility>
 #include <vector>
 
-#include <boost/algorithm/string/case_conv.hpp>
-
 #include <casa/Quanta/MVAngle.h>
 
 using namespace casacore;
@@ -65,6 +63,7 @@ namespace DP3 {
           itsUpdateWeights(parset.getBool(prefix + "updateweights", false)),
           itsDirectionStr(parset.getStringVector(prefix+"direction", std::vector<std::string>())),
           itsUseChannelFreq(parset.getBool(prefix + "usechannelfreq", true)),
+          itsMode(StringToBeamCorrectionMode(parset.getString(prefix + "beammode", "default"))),
           itsModeAtStart(NoBeamCorrection),
           itsDebugLevel(parset.getInt(prefix + "debuglevel", 0))
     {
@@ -74,16 +73,6 @@ namespace DP3 {
         itsInvert=false;
       } else {
         itsInvert=parset.getBool(prefix + "invert", true);
-      }
-      string mode=boost::to_lower_copy(parset.getString(prefix + "beammode","default"));
-      if (mode=="default") {
-        itsMode=FullBeamCorrection;
-      } else if (mode=="array_factor") {
-        itsMode=ArrayFactorBeamCorrection;
-      } else if (mode=="element") {
-        itsMode=ElementBeamCorrection;
-      } else {
-        throw Exception("Beammode should be DEFAULT, ARRAY_FACTOR or ELEMENT");
       }
     }
 

--- a/DPPP/DPInfo.h
+++ b/DPPP/DPInfo.h
@@ -35,6 +35,8 @@
 
 #include "../Common/ThreadPool.h"
 
+#include <boost/algorithm/string/case_conv.hpp>
+
 namespace DP3 {
   namespace DPPP {
 
@@ -56,6 +58,20 @@ namespace DP3 {
         case FullBeamCorrection: return "full";
         case ArrayFactorBeamCorrection: return "array_factor";
         case ElementBeamCorrection: return "element";
+      }
+    }
+
+    inline BeamCorrectionMode StringToBeamCorrectionMode(const std::string& str)
+    {
+      string mode=boost::to_lower_copy(str);
+      if (mode=="default" || mode=="full") {
+        return FullBeamCorrection;
+      } else if (mode=="array_factor") {
+        return ArrayFactorBeamCorrection;
+      } else if (mode=="element") {
+        return ElementBeamCorrection;
+      } else {
+        throw std::runtime_error("Beammode should be DEFAULT, ARRAY_FACTOR or ELEMENT");
       }
     }
 

--- a/DPPP/DPRun.cc
+++ b/DPPP/DPRun.cc
@@ -48,6 +48,7 @@
 #include "PreFlagger.h"
 #include "ProgressMeter.h"
 #include "ScaleData.h"
+#include "SetBeam.h"
 #include "Split.h"
 #include "StationAdder.h"
 #include "UVWFlagger.h"
@@ -361,6 +362,8 @@ namespace DP3 {
           step = DPStep::ShPtr(new StationAdder (reader, parset, prefix));
         } else if (type == "scaledata") {
           step = DPStep::ShPtr(new ScaleData (reader, parset, prefix));
+        } else if (type == "setbeam") {
+          step = DPStep::ShPtr(new SetBeam (reader, parset, prefix));
         } else if (type == "filter") {
           step = DPStep::ShPtr(new Filter (reader, parset, prefix));
         } else if (type == "applycal"  ||  type == "correct") {

--- a/DPPP/SetBeam.cc
+++ b/DPPP/SetBeam.cc
@@ -1,0 +1,61 @@
+#include <iostream>
+
+#include "../Common/ParameterSet.h"
+#include "../Common/StreamUtil.h"
+
+#include "DPInfo.h"
+#include "SetBeam.h"
+
+#include <casacore/casa/Quanta/MVAngle.h>
+
+namespace DP3 {
+namespace DPPP {
+  
+SetBeam::SetBeam(DPInput* input, const ParameterSet& parset, const string& prefix) :
+  _input(input),
+  _name(prefix),
+  _directionStr(parset.getStringVector(prefix+"direction", std::vector<std::string>())),
+  _mode(ElementBeamCorrection)
+{
+}
+
+void SetBeam::updateInfo(const DPInfo& dpInfo)
+{
+  info() = dpInfo;
+  
+  // Parse direction parset value
+  if (_directionStr.empty())
+    _direction = info().phaseCenter();
+  else {
+    if (_directionStr.size() != 2)
+      throw std::runtime_error("2 values must be given in direction option of SetBeam");
+    casacore::MDirection phaseCenter;
+    casacore::Quantity q0, q1;
+    if (!casacore::MVAngle::read (q0, _directionStr[0]))
+      throw std::runtime_error(_directionStr[0] + " is an invalid RA or longitude in SetBeam direction");
+    if (!casacore::MVAngle::read (q1, _directionStr[1]))
+      throw std::runtime_error(_directionStr[1] + " is an invalid DEC or latitude in SetBeam direction");
+    casacore::MDirection::Types type = casacore::MDirection::J2000;
+    _direction = casacore::MDirection(q0, q1, type);
+  }
+  
+  info().setBeamCorrectionMode(_mode);
+  info().setBeamCorrectionDir(_direction);
+  
+}
+
+void SetBeam::show(std::ostream& os) const
+{
+  os
+  << "SetBeam " << _name << '\n'
+  << "  mode:              " << BeamCorrectionModeToString(_mode) << '\n'
+  << "  direction:         " << _directionStr << '\n';
+}
+
+bool SetBeam::process(const DPBuffer& buffer)
+{
+  getNextStep()->process(buffer);
+  return false;
+}
+
+}} //# end namespaces

--- a/DPPP/SetBeam.cc
+++ b/DPPP/SetBeam.cc
@@ -15,7 +15,7 @@ SetBeam::SetBeam(DPInput* input, const ParameterSet& parset, const string& prefi
   _input(input),
   _name(prefix),
   _directionStr(parset.getStringVector(prefix+"direction", std::vector<std::string>())),
-  _mode(ElementBeamCorrection)
+  _mode(StringToBeamCorrectionMode(parset.getString(prefix + "beammode", "default")))
 {
 }
 

--- a/DPPP/SetBeam.h
+++ b/DPPP/SetBeam.h
@@ -1,0 +1,44 @@
+#ifndef DPPP_SETBEAM_H
+#define DPPP_SETBEAM_H
+
+// @file
+// @brief DPPP step class to set the beam keywords in a ms
+
+#include "DPInput.h"
+#include "DPBuffer.h"
+#include "Position.h"
+
+#include <casacore/measures/Measures/MDirection.h>
+
+namespace DP3 {
+
+class ParameterSet;
+
+namespace DPPP {
+  
+class SetBeam final : public DPStep
+{
+public:
+  // Parameters are obtained from the parset using the given prefix.
+  SetBeam (DPInput* input, const ParameterSet& parameters, const string& prefix);
+
+  bool process(const DPBuffer& buffer) override;
+
+  void finish() override { };
+
+  void updateInfo(const DPInfo& info) override;
+
+  void show(std::ostream&) const override;
+  
+private:
+  DPInput* _input;
+  string _name;
+  std::vector<string> _directionStr;
+  casacore::MDirection _direction;
+  BeamCorrectionMode _mode;
+};
+
+} } //# end namespaces
+
+#endif
+


### PR DESCRIPTION
This is useful after a predict (with DP3 or image based with e.g. wsclean) in which no consideration 
of the beam was applied. In that case, the visibilities are "corrected" for the beam towards an arbitrary direction. If one source is predicted, it is as if the beam is corrected for in that direction.

This new step makes that possible, and e.g. to unapply/corrupt for the beam after having predicted/fted the visibilities afterwards.

This fixes #236.