### PR TITLE
build: fixup python search and support BLAS_LIBS, LAPACK_LIBS

### DIFF
--- a/CMake/FindCasacore.cmake
+++ b/CMake/FindCasacore.cmake
@@ -17,6 +17,8 @@
 #
 # Variables used by this module:
 #  CASACORE_ROOT_DIR         - Casacore root directory. 
+#  BLAS_LIBS                 - override BLAS library
+#  LAPACK_LIBS               - override LAPACK library
 #
 # Variables defined by this module:
 #  CASACORE_FOUND            - System has Casacore, which means that the
@@ -232,7 +234,21 @@ else(NOT CASACORE_INCLUDE_DIR)
     elseif(${_comp} STREQUAL fits)
       casacore_find_package(CFITSIO REQUIRED)
     elseif(${_comp} STREQUAL scimath_f)
-      casacore_find_package(LAPACK REQUIRED)
+      # If only looking for LAPACK, no library will be added if LAPACK
+      # is part of BLAS, as it is customary nowadays. So look for both
+      # to avoid confusing linker errors on symbols used in headers/templates.
+      if(DEFINED ENV{BLAS_LIBS})
+        set(BLAS_FOUND YES)
+        list(APPEND CASACORE_LIBRARIES $ENV{BLAS_LIBS})
+      else()
+        casacore_find_package(BLAS   REQUIRED)
+      endif()
+      if(DEFINED ENV{LAPACK_LIBS})
+        set(LAPACK_FOUND YES)
+        list(APPEND CASACORE_LIBRARIES $ENV{LAPACK_LIBS})
+      else()
+        casacore_find_package(LAPACK REQUIRED)
+      endif()
     endif(${_comp} STREQUAL casa)
   endforeach(_comp ${_find_components})
 endif(NOT CASACORE_INCLUDE_DIR)

--- a/CMake/PythonInstall.cmake
+++ b/CMake/PythonInstall.cmake
@@ -24,10 +24,11 @@
 # $Id: PythonInstall.cmake 32905 2015-11-17 15:31:54Z schaap $
 
 # Search for the Python interpreter.
-find_package(PythonInterp)
+# No. We expect the toplevel CMakeLists.txt to have found python already!
+#find_package(PythonInterp)
 
 # Derive the Python site-packages installation directory and build directory.
-if(PYTHON_EXECUTABLE)
+if(Python3_EXECUTABLE)
   set(_cmd
     "from distutils.sysconfig import get_python_lib"
     "from os.path import join"
@@ -36,7 +37,7 @@ if(PYTHON_EXECUTABLE)
        'site-packages'))"
   )
   execute_process(
-    COMMAND "${PYTHON_EXECUTABLE}" "-c" "${_cmd}"
+    COMMAND "${Python3_EXECUTABLE}" "-c" "${_cmd}"
     OUTPUT_VARIABLE _pydir
     ERROR_VARIABLE _pyerr
     OUTPUT_STRIP_TRAILING_WHITESPACE)
@@ -57,7 +58,7 @@ if(PYTHON_EXECUTABLE)
     message(STATUS "Build directory for Python extensions:        ${PYTHON_BUILD_DIR}")
     message(STATUS "Installation directory for Python extensions: ${PYTHON_INSTALL_DIR}")
   endif()
-endif(PYTHON_EXECUTABLE)
+endif(Python3_EXECUTABLE)
 
 
 #
@@ -66,9 +67,9 @@ endif(PYTHON_EXECUTABLE)
 macro(python_install)
 
   # Precondition check.
-  if(NOT PYTHON_EXECUTABLE)
+  if(NOT Python3_EXECUTABLE)
     message(FATAL_ERROR "python_install: Python interpreter not available")
-  endif(NOT PYTHON_EXECUTABLE)
+  endif(NOT Python3_EXECUTABLE)
 
   # Parse arguments.
   # apart from the python files list, there are two additional arguments

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,13 +44,14 @@ endif(IDGAPI_LIBRARIES AND IDGAPI_INCLUDE_DIRS)
 
 find_package(CFITSIO REQUIRED)
 
-find_package(PythonLibs 3 REQUIRED)
-find_package(PythonInterp REQUIRED)
-message(STATUS "Using python version ${PYTHON_VERSION_STRING}")
+find_package(Python3 COMPONENTS Interpreter Development)
+message(STATUS "Using python version ${Python3_VERSION}")
+
+include_directories(${Python3_INCLUDE_DIRS})
 
 #Prevent accidentally finding old BoostConfig.cmake file from casapy
 set(Boost_NO_BOOST_CMAKE ON)
-set(BOOSTPY ${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
+set(BOOSTPY ${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR})
 find_package(Boost COMPONENTS date_time filesystem python${BOOSTPY} numpy${BOOSTPY} program_options system unit_test_framework REQUIRED)
 include_directories(${Boost_INCLUDE_DIR})
 
@@ -236,7 +237,7 @@ set(EXTRA_LIBRARIES ${EXTRA_LIBRARIES}
   ${CASACORE_LIBRARIES}
   ${Boost_LIBRARIES}
   ${EXTRA_LIBRARIES}
-  ${PYTHON_LIBRARIES}
+  ${Python3_LIBRARIES}
   ${IDGAPI_LIBRARIES}
   Threads::Threads)
   

--- a/PythonDPPP/CMakeLists.txt
+++ b/PythonDPPP/CMakeLists.txt
@@ -1,5 +1,5 @@
-# If Boost-Python3 found, build this package. Otherwise give a warning.
-if(${Boost_PYTHON${BOOSTPY}_FOUND})
+# We set Boost-python as required in toplevel build file.
+if(TRUE)
 
   include(PythonInstall)
 
@@ -25,20 +25,7 @@ if(${Boost_PYTHON${BOOSTPY}_FOUND})
   # Install Python modules
   python_install(__init__.py DESTINATION lofar/pythondppp)
 
-	find_package(PythonInterp REQUIRED)
-  find_package(PythonLibs 3 REQUIRED)
-  include_directories(${PYTHON_INCLUDE_DIRS})
-
-  if(${PYTHON_VERSION_MAJOR} EQUAL 2)
-    find_package(Casacore COMPONENTS python)
-  else()
-    find_package(Casacore COMPONENTS python3)
-  endif()
+  find_package(Casacore COMPONENTS python3)
   
-  find_package(Boost REQUIRED COMPONENTS python${BOOSTPY})
-  include_directories(${Boost_INCLUDE_DIR})
-
 #  add_subdirectory(test)
-else()
-  message (WARNING, " Boost-Python not found; PythonDPPP will not be built.")
 endif()


### PR DESCRIPTION
This is a set of changes we carry at Universität Hamburg to get
the LOFAR toolchain built. I hope it can be included upstream, or
at least something equivalent.

Important points are:

-  Use current (less deprecated) cmake ways to detect Python 3.
-  Less redundancy in Python checking in CMakeLists at deeper level
   (Always try to build PythonDPPP as Python and Boost is required
   anyway.)
-  Add support for BLAS_LIBS and LAPACK_LIBS, as this is
   customary in HPC installations to choose the (optimized) BLAS
   implementation in an environment that offers multiple options.

The last point is repeated in other patches we carry for the LOFAR
stack. Maybe the common source for the FindCasacore code should
be patched instead?

The motivation for us is to get the build going while being able to select
python and BLAS/LAPACK implementations using environment modules.

Edit: Remove Boost::pythonXY motivation, as this is already in current DPPP,
the change there is only the way of finding Python 3.