### PR TITLE
Baseline description now mentions the most common example

### DIFF
--- a/docs/schemas/Description of baseline selection parameters.yml
+++ b/docs/schemas/Description of baseline selection parameters.yml
@@ -17,8 +17,9 @@ inputs:
       Names of baselines to be matched. It can be given as either a vector of vectors or as a casacore MSSelection string. 
       These two methods are mutually exclusive. When in doubt, use the second syntax.1. If given as a vector, a vector 
       element can be a vector of two names giving the stations forming a baseline. For example: ``baseline=[ [CS001,RS003], [CS002,RS005] ]`` 
-      selects baselines CS001-RS003 and CS002-RS005, and ``baseline=[CS401HBA0, CS401HBA1, RS205HBA]`` selects baselines that are formed
-      from any of those antennas. The latter is a typical selection string to remove a few stations with the :doc:`Filter` step.
+      selects baselines CS001-RS003 and CS002-RS005. A common syntax for the :doc:`Filter` is ``baseline=!CS401HBA0,CS401HBA1,RS205HBA``,
+      which filters baselines that are formed
+      from any of those antennas.
       Each name can be a shell-type pattern (with wildcards * ? [] or {}). Thus ``baseline=[ [CS*,RS*] ]`` 
       selects all baselines between core and remote stations. Note that the wildcard characters {} mean OR. They can be used to pair groups of 
       stations (quotes are needed). For example: ``baseline=[ ["{CS001,CS002}","{RS003,RS005}"] ]`` selects baselines CS001-RS003, CS001-RS005, CS002-RS003, 

--- a/docs/schemas/Description of baseline selection parameters.yml
+++ b/docs/schemas/Description of baseline selection parameters.yml
@@ -17,7 +17,9 @@ inputs:
       Names of baselines to be matched. It can be given as either a vector of vectors or as a casacore MSSelection string. 
       These two methods are mutually exclusive. When in doubt, use the second syntax.1. If given as a vector, a vector 
       element can be a vector of two names giving the stations forming a baseline. For example: ``baseline=[ [CS001,RS003], [CS002,RS005] ]`` 
-      selects baselines CS001-RS003 and CS002-RS005. Each name can be a shell-type pattern (with wildcards * ? [] or {}). Thus ``baseline=[ [CS*,RS*] ]`` 
+      selects baselines CS001-RS003 and CS002-RS005, and ``baseline=[CS401HBA0, CS401HBA1, RS205HBA]`` selects baselines that are formed
+      from any of those antennas. The latter is a typical selection string to remove a few stations with the :doc:`Filter` step.
+      Each name can be a shell-type pattern (with wildcards * ? [] or {}). Thus ``baseline=[ [CS*,RS*] ]`` 
       selects all baselines between core and remote stations. Note that the wildcard characters {} mean OR. They can be used to pair groups of 
       stations (quotes are needed). For example: ``baseline=[ ["{CS001,CS002}","{RS003,RS005}"] ]`` selects baselines CS001-RS003, CS001-RS005, CS002-RS003, 
       and CS002-RS005. Besides giving a baseline, it is also possible to give a single station name (possibly wildcarded) meaning that all baselines 

--- a/docs/schemas/Filter.yml
+++ b/docs/schemas/Filter.yml
@@ -34,7 +34,7 @@ inputs:
     default: "\"\""
     type: double?
     doc: >-
-      Baselines to keep. See :ref:`Description of baseline selection parameters`. 
+      ???
   corrtype:
     default: '""'
     type: string

--- a/docs/schemas/Filter.yml
+++ b/docs/schemas/Filter.yml
@@ -29,12 +29,12 @@ inputs:
     default: "\"\""
     type: string
     doc: >-
-      Baselines to keep. See :ref:`Description of baseline selection parameters`. 
+      Baseline to keep using a selection string. See :ref:`Description of baseline selection parameters`. 
   blrange:
     default: "\"\""
-    type: double?
+    type: array
     doc: >-
-      ???
+      Baseline to keep using a range. See :ref:`Description of baseline selection parameters`. 
   corrtype:
     default: '""'
     type: string


### PR DESCRIPTION
Also, there's an error in the Filter description.