### PR TITLE
Use add_compile_options; Remove CMAKE_CXX_FLAGS_CUSTOM.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,16 +6,15 @@ project(DP3)
 
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/CMake)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -O3")
+add_compile_options(-Wall -O3)
 
 if(NOT PORTABLE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+  add_compile_options(-march=native)
 endif()
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_CUSTOM}")
 include(CTest)
 enable_testing()
 


### PR DESCRIPTION
Recently I introduced CMAKE_CXX_FLAGS_CUSTOM since cmake -DCMAKE_CXX_FLAGS=xxx didn't work. Now it suddenly does, so I want to remove this unused item.

I also replaced two 'set' commands by 'add_compile_options'.