### PR TITLE
Fix baseline selection bug when using new casacore version

### DIFF
--- a/Common/BaselineSelect.cc
+++ b/Common/BaselineSelect.cc
@@ -58,15 +58,15 @@ namespace DP3 {
       Vector<Int> a2 = ROScalarColumn<Int>(tab, "ANTENNA2").getColumn();
       int nant = 1 + std::max(max(a1), max(a2));
       Matrix<bool> bl(nant, nant, false);
-      vector<uInt> rows;
+      vector<rownr_t> rows;
       rows.reserve (nant*nant);
-      for (unsigned int i=0; i<a1.size(); ++i) {
+      for (rownr_t i=0; i<a1.size(); ++i) {
         if (! bl(a1[i], a2[i])) {
           rows.push_back (i);
           bl(a1[i], a2[i]) = true;
         }
       }
-      bltab = tab(Vector<uInt>(rows));
+      bltab = tab(Vector<rownr_t>(rows));
     }
     TableExprNode a1 (bltab.col("ANTENNA1"));
     TableExprNode a2 (bltab.col("ANTENNA2"));

--- a/Common/BaselineSelect.cc
+++ b/Common/BaselineSelect.cc
@@ -40,6 +40,8 @@
 #include <casacore/casa/Arrays/Vector.h>
 #include <casacore/casa/version.h>
 
+#include "Types.h"
+
 using namespace casacore;
 
 namespace DP3 {
@@ -134,7 +136,7 @@ namespace DP3 {
     try {
       // Create a table expression representing the selection.
       TableExprNode node = msAntennaGramParseCommand
-        (anttab, a1, a2, baselineSelection, 
+        (anttab, a1, a2, baselineSelection,
          selectedAnts1, selectedAnts2, selectedBaselines);
       // Get the antenna numbers.
       Table seltab = node.table()(node);

--- a/Common/Types.h
+++ b/Common/Types.h
@@ -1,0 +1,39 @@
+// Types.h: Define common types.
+// Copyright (C) 2020
+// ASTRON (Netherlands Institute for Radio Astronomy)
+// P.O.Box 2, 7990 AA Dwingeloo, The Netherlands
+//
+// This file is part of the LOFAR software suite.
+// The LOFAR software suite is free software: you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The LOFAR software suite is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with the LOFAR software suite. If not, see <http://www.gnu.org/licenses/>.
+
+/// @file
+/// @brief Define common types.
+/// @author Maik Nijhuis
+
+#ifndef COMMON_TYPES_H
+#define COMMON_TYPES_H
+
+#include <casacore/casa/version.h>
+
+namespace DP3 {
+
+#if CASACORE_MAJOR_VERSION<3 || (CASACORE_MAJOR_VERSION==3 && CASACORE_MINOR_VERSION<4)
+  typedef unsigned int rownr_t;
+#else
+  typedef casacore::rownr_t rownr_t;
+#endif
+
+}
+
+#endif

--- a/DPPP/DPBuffer.h
+++ b/DPPP/DPBuffer.h
@@ -27,17 +27,11 @@
 #include <casacore/casa/Arrays/Vector.h>
 #include <casacore/casa/Arrays/Cube.h>
 #include <casacore/casa/BasicSL/Complex.h>
-#include <casacore/casa/version.h>
+
+#include "../Common/Types.h"
 
 namespace DP3 {
   namespace DPPP {
-
-
-#if CASACORE_MAJOR_VERSION<3 || (CASACORE_MAJOR_VERSION==3 && CASACORE_MINOR_VERSION<4)
-    typedef unsigned int rownr_t;
-#else
-    typedef casacore::rownr_t rownr_t;
-#endif
 
     /// @brief Buffer holding the data of a timeslot/band
 

--- a/DPPP/test/unit/tAverager.cc
+++ b/DPPP/test/unit/tAverager.cc
@@ -223,7 +223,7 @@ private:
     buf.setData (data);
     buf.setWeights (weights);
     buf.setFlags (flags);
-    vector<DP3::DPPP::rownr_t> rownrs(1,itsCount);
+    vector<DP3::rownr_t> rownrs(1,itsCount);
     buf.setRowNrs (rownrs);
     getNextStep()->process (buf);
     ++itsCount;

--- a/ParmDB/ParmDBCasa.h
+++ b/ParmDB/ParmDBCasa.h
@@ -30,20 +30,14 @@
 #include <casacore/casa/Arrays/Array.h>
 #include <casacore/tables/Tables/Table.h>
 #include <casacore/tables/Tables/ArrayColumn.h>
-#include <casacore/casa/version.h>
 
+#include "../Common/Types.h"
 
 namespace DP3 {
 namespace BBS {
 
   /// @ingroup ParmDB
   /// @{
-
-#if CASACORE_MAJOR_VERSION<3 || (CASACORE_MAJOR_VERSION==3 && CASACORE_MINOR_VERSION<4)
-  typedef unsigned int rownr_t;
-#else
-  typedef casacore::rownr_t rownr_t;
-#endif
 
   /// @brief Class to hold parameters in a Casa table
   class ParmDBCasa : public ParmDBRep

--- a/ParmDB/SourceDBCasa.h
+++ b/ParmDB/SourceDBCasa.h
@@ -31,6 +31,8 @@
 #include <casacore/tables/Tables/Table.h>
 #include <casacore/casa/version.h>
 
+#include "../Common/Types.h"
+
 #include <set>
 
 namespace DP3 {
@@ -38,12 +40,6 @@ namespace BBS {
 
   /// @ingroup ParmDB
   /// @{
-
-#if CASACORE_MAJOR_VERSION<3 || (CASACORE_MAJOR_VERSION==3 && CASACORE_MINOR_VERSION<4)
-  typedef unsigned int rownr_t;
-#else
-  typedef casacore::rownr_t rownr_t;
-#endif
 
   /// @brief Class for a Casa table holding source parameters.
   class SourceDBCasa : public SourceDBRep


### PR DESCRIPTION
The change of casacore to 64 bit rownrs has caused a subtle bug in baseline selection (caused by overloading TableNodeExpr with every type in the Universe). This bug would be present on all platforms with a recent casacore version. These changes also solve the two GainCal integration tests.