### PR TITLE
Make formatting script robust against premature wildcard expansion

### DIFF
--- a/scripts/run-clang-format.sh
+++ b/scripts/run-clang-format.sh
@@ -9,6 +9,9 @@
 # "./scripts/run-clang-format.sh" to .git/hooks/pre-commit
 # and make sure pre-commit is an executable shell script.
 
+# Disable globbing
+set -e -f
+
 #Script configuration for this repo. Adjust it when copying to a different repo.
 
 #The directory that contains the source files, which clang-format should format.
@@ -22,8 +25,6 @@ EXCLUDE_DIRS=(external)
 SOURCE_EXT=(*.cc *.h)
 
 #End script configuration.
-
-set -e
 
 # Detect run environment.
 if [ -n "$CI" ]; then


### PR DESCRIPTION
In another repo (wsclean), I noticed that the formatting script was not robust against premature wildcard expansions. For instance, if there are cpp files (e.g. *.h, *.cc) present in the `SOURCE_DIR` the wildcards are expanded into file names in `SOURCE_DIR`,  before searching the `SOURCE_DIR/subdirs`. Hence, many of the cpp files in subdirectories of the `SOURCE_DIR` are skipped. This definitely is unwanted behaviour.

In order to avoid this, the script now first `cd`'s into the script directory and specify the `SOURCE_DIR` relative to this `SCRIPT_PATH`. `EXCLUDE_DIRS` is now also relative to the `SCRIPT_PATH`, but can be straightforwardly changed into something which is relative to `SOURCE_DIR`